### PR TITLE
Fix test suite crashes caused by Swift Testing framework

### DIFF
--- a/Tests/AppTests/Framework/Base/PerformanceTestCase.swift
+++ b/Tests/AppTests/Framework/Base/PerformanceTestCase.swift
@@ -1,5 +1,5 @@
 @testable import App
-import Testing
+import XCTest
 import Vapor
 
 /// Base test case for performance and benchmarking tests.

--- a/Tests/AppTests/Framework/Base/UnitTestCase.swift
+++ b/Tests/AppTests/Framework/Base/UnitTestCase.swift
@@ -1,5 +1,5 @@
 @testable import App
-import Testing
+import XCTest
 import Vapor
 
 /// Base test case for unit tests that test individual services, repositories, and business logic.

--- a/Tests/AppTests/Framework/TestWorld.swift
+++ b/Tests/AppTests/Framework/TestWorld.swift
@@ -190,21 +190,9 @@ class TestWorld: @unchecked Sendable {
     /// - Returns: Configured test application
     /// - Throws: Configuration errors
     static func makeTestAppSync() throws -> Application {
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<Application, Error>!
-        
-        Task {
-            do {
-                let app = try await makeTestApp()
-                result = .success(app)
-            } catch {
-                result = .failure(error)
-            }
-            semaphore.signal()
-        }
-        
-        semaphore.wait()
-        return try result.get()
+        let app = Application(.testing)
+        try configure(app)
+        return app
     }
     
     /// Creates a TestWorld with a new async application.


### PR DESCRIPTION
## Summary
- Removed Swift Testing framework dependencies that were causing test crashes
- Fixed Application initialization to prevent ServeCommand assertion failures
- Restored test suite functionality with 102/105 tests passing

## Problem
The test suite was crashing with signal code 5 and showing the error:
```
Vapor/ServeCommand.swift:131: Assertion failed: ServeCommand did not shutdown before deinit
```

This was caused by:
1. Mixed usage of Swift Testing and XCTest frameworks
2. Incorrect Application initialization in async contexts

## Solution
1. Replaced `import Testing` with `import XCTest` in test base classes
2. Modified `TestWorld.makeTestAppSync()` to use synchronous `Application(.testing)` constructor
3. Removed unnecessary async wrapper code

## Test Results
- ✅ 102 tests passing
- ❌ 3 tests failing (unrelated configuration test expectations)
- No more crashes or assertion failures

## Changes Made
- `Tests/AppTests/Framework/Base/UnitTestCase.swift` - Replaced Testing import
- `Tests/AppTests/Framework/Base/PerformanceTestCase.swift` - Replaced Testing import  
- `Tests/AppTests/Framework/TestWorld.swift` - Fixed Application initialization

🤖 Generated with [Claude Code](https://claude.ai/code)