### PR TITLE
feat(waitlist): add waitlist email collection & notification system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ railway-project-id.txt
 # Environment-specific files (keep examples)
 .env.staging
 .env.production
+
+# Linear
+.linear

--- a/Sources/App/Entrypoint/Application-Setup.swift
+++ b/Sources/App/Entrypoint/Application-Setup.swift
@@ -86,6 +86,7 @@ extension Application {
       FrontendModule(),
       RulesGenerationModule(),
       CacheAdminModule(),
+      WaitlistModule(),
     ]
 
     for module in modules {

--- a/Sources/App/Middlewares/Security/RateLimit/RateLimitMiddleware.swift
+++ b/Sources/App/Middlewares/Security/RateLimit/RateLimitMiddleware.swift
@@ -184,6 +184,15 @@ struct RateLimitMiddleware: AsyncMiddleware {
             )
         }
         
+        // Waitlist endpoints - must be before general /api/ catch-all
+        if path.hasPrefix("/api/waitlist") {
+            return RateLimitInfo(
+                type: .waitlist,
+                maxRequests: 10,  // 10 requests per hour
+                windowSeconds: 3600  // 1 hour window
+            )
+        }
+
         // Admin endpoints
         if path.contains("/api/admin/") {
             return RateLimitInfo(
@@ -192,7 +201,7 @@ struct RateLimitMiddleware: AsyncMiddleware {
                 windowSeconds: configuration.adminWindow
             )
         }
-        
+
         // API endpoints
         if path.hasPrefix("/api/") {
             return RateLimitInfo(

--- a/Sources/App/Middlewares/Security/RateLimit/RateLimitTypes.swift
+++ b/Sources/App/Middlewares/Security/RateLimit/RateLimitTypes.swift
@@ -79,6 +79,19 @@ enum RateLimitType: String, CaseIterable {
     ///
     /// **Typical Limits**: 500-10,000 requests per hour depending on environment
     case general = "general"
+
+    /// Waitlist subscription operations for the public signup endpoint.
+    ///
+    /// **Restrictive Category**
+    ///
+    /// Applied to waitlist endpoints including:
+    /// - Email subscription signup
+    /// - Unsubscribe requests
+    ///
+    /// This protects against automated spam while allowing legitimate signups.
+    ///
+    /// **Typical Limits**: 10 requests per hour
+    case waitlist = "waitlist"
 }
 
 /// Container for rate limit information specific to an operation type.

--- a/Sources/App/Modules/Waitlist/Database/Migrations/WaitlistMigrations.swift
+++ b/Sources/App/Modules/Waitlist/Database/Migrations/WaitlistMigrations.swift
@@ -1,0 +1,24 @@
+import Fluent
+import Vapor
+
+enum WaitlistMigrations {
+
+    struct v1: AsyncMigration {
+
+        func prepare(on db: Database) async throws {
+            try await db.schema(WaitlistEntryModel.schema)
+                .id()
+                .field(WaitlistEntryModel.FieldKeys.v1.email, .string, .required)
+                .field(WaitlistEntryModel.FieldKeys.v1.unsubscribeToken, .string, .required)
+                .field(WaitlistEntryModel.FieldKeys.v1.createdAt, .datetime)
+                .field(WaitlistEntryModel.FieldKeys.v1.notifiedAt, .datetime)
+                .unique(on: WaitlistEntryModel.FieldKeys.v1.email)
+                .unique(on: WaitlistEntryModel.FieldKeys.v1.unsubscribeToken)
+                .create()
+        }
+
+        func revert(on db: Database) async throws {
+            try await db.schema(WaitlistEntryModel.schema).delete()
+        }
+    }
+}

--- a/Sources/App/Modules/Waitlist/Database/Models/WaitlistEntryModel.swift
+++ b/Sources/App/Modules/Waitlist/Database/Models/WaitlistEntryModel.swift
@@ -1,0 +1,45 @@
+import Fluent
+import Vapor
+
+final class WaitlistEntryModel: @unchecked Sendable, DatabaseModelInterface {
+    typealias Module = WaitlistModule
+    static var schema: String { "waitlist_entries" }
+
+    @ID()
+    var id: UUID?
+
+    @Field(key: FieldKeys.v1.email)
+    var email: String
+
+    @Field(key: FieldKeys.v1.unsubscribeToken)
+    var unsubscribeToken: String
+
+    @Timestamp(key: FieldKeys.v1.createdAt, on: .create)
+    var createdAt: Date?
+
+    @OptionalField(key: FieldKeys.v1.notifiedAt)
+    var notifiedAt: Date?
+
+    init() { }
+
+    init(
+        id: UUID? = nil,
+        email: String,
+        unsubscribeToken: String = UUID().uuidString
+    ) {
+        self.id = id
+        self.email = email
+        self.unsubscribeToken = unsubscribeToken
+    }
+}
+
+extension WaitlistEntryModel {
+    struct FieldKeys {
+        struct v1 {
+            static var email: FieldKey { "email" }
+            static var unsubscribeToken: FieldKey { "unsubscribe_token" }
+            static var createdAt: FieldKey { "created_at" }
+            static var notifiedAt: FieldKey { "notified_at" }
+        }
+    }
+}

--- a/Sources/App/Modules/Waitlist/Models/Waitlist+Model.swift
+++ b/Sources/App/Modules/Waitlist/Models/Waitlist+Model.swift
@@ -1,0 +1,40 @@
+import Vapor
+
+enum Waitlist {
+    enum Subscribe {
+        struct Request: Content, Validatable {
+            let email: String
+
+            static func validations(_ validations: inout Validations) {
+                validations.add("email", as: String.self, is: .email)
+            }
+        }
+
+        struct Response: Content {
+            let message: String
+            let email: String
+        }
+    }
+
+    enum Unsubscribe {
+        struct Response: Content {
+            let message: String
+        }
+    }
+
+    enum Stats {
+        struct Response: Content {
+            let total: Int
+            let notified: Int
+            let pending: Int
+        }
+    }
+
+    enum Notify {
+        struct Response: Content {
+            let sent: Int
+            let failed: Int
+            let message: String
+        }
+    }
+}

--- a/Sources/App/Modules/Waitlist/Repositories/WaitlistRepository.swift
+++ b/Sources/App/Modules/Waitlist/Repositories/WaitlistRepository.swift
@@ -1,0 +1,76 @@
+import Fluent
+import Vapor
+
+protocol WaitlistRepository: Repository {
+    func find(id: UUID) async throws -> WaitlistEntryModel?
+    func find(email: String) async throws -> WaitlistEntryModel?
+    func find(token: String) async throws -> WaitlistEntryModel?
+    func create(_ model: WaitlistEntryModel) async throws
+    func delete(_ model: WaitlistEntryModel) async throws
+    func all() async throws -> [WaitlistEntryModel]
+    func findUnnotified() async throws -> [WaitlistEntryModel]
+    func update(_ model: WaitlistEntryModel) async throws
+    func count() async throws -> Int
+    func countNotified() async throws -> Int
+}
+
+struct DatabaseWaitlistRepository: WaitlistRepository, DatabaseRepository {
+    typealias Model = WaitlistEntryModel
+    let database: Database
+
+    func find(id: UUID) async throws -> WaitlistEntryModel? {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$id == id)
+            .first()
+    }
+
+    func find(email: String) async throws -> WaitlistEntryModel? {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$email == email)
+            .first()
+    }
+
+    func find(token: String) async throws -> WaitlistEntryModel? {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$unsubscribeToken == token)
+            .first()
+    }
+
+    func create(_ model: WaitlistEntryModel) async throws {
+        try await model.create(on: database)
+    }
+
+    func delete(_ model: WaitlistEntryModel) async throws {
+        try await model.delete(on: database)
+    }
+
+    func all() async throws -> [WaitlistEntryModel] {
+        try await WaitlistEntryModel.query(on: database).all()
+    }
+
+    func findUnnotified() async throws -> [WaitlistEntryModel] {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$notifiedAt == nil)
+            .all()
+    }
+
+    func update(_ model: WaitlistEntryModel) async throws {
+        try await model.update(on: database)
+    }
+
+    func count() async throws -> Int {
+        try await WaitlistEntryModel.query(on: database).count()
+    }
+
+    func countNotified() async throws -> Int {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$notifiedAt != nil)
+            .count()
+    }
+}
+
+extension Request.Services {
+    var waitlist: any WaitlistRepository {
+        DatabaseWaitlistRepository(database: request.db)
+    }
+}

--- a/Sources/App/Modules/Waitlist/WaitlistController.swift
+++ b/Sources/App/Modules/Waitlist/WaitlistController.swift
@@ -1,0 +1,96 @@
+import Vapor
+
+struct WaitlistController {
+
+    func subscribe(_ req: Request) async throws -> Waitlist.Subscribe.Response {
+        try Waitlist.Subscribe.Request.validate(content: req)
+        let subscribeRequest = try req.content.decode(Waitlist.Subscribe.Request.self)
+
+        let repository = req.services.waitlist
+
+        // Check for existing entry (idempotent)
+        if let existing = try await repository.find(email: subscribeRequest.email) {
+            return Waitlist.Subscribe.Response(
+                message: "You're already on the waitlist!",
+                email: existing.email
+            )
+        }
+
+        // Create new entry
+        let entry = WaitlistEntryModel(email: subscribeRequest.email)
+        try await repository.create(entry)
+
+        // Send confirmation email (fire and forget - don't fail on email error)
+        Task {
+            do {
+                try await req.waitlistNotifier.sendConfirmation(to: entry)
+            } catch {
+                req.logger.error("Failed to send waitlist confirmation email: \(error)")
+            }
+        }
+
+        return Waitlist.Subscribe.Response(
+            message: "Thanks for joining the waitlist!",
+            email: entry.email
+        )
+    }
+
+    func unsubscribe(_ req: Request) async throws -> Waitlist.Unsubscribe.Response {
+        guard let token = req.parameters.get("token") else {
+            throw Abort(.badRequest, reason: "Missing unsubscribe token")
+        }
+
+        let repository = req.services.waitlist
+
+        guard let entry = try await repository.find(token: token) else {
+            throw Abort(.notFound, reason: "Invalid or expired unsubscribe link")
+        }
+
+        try await repository.delete(entry)
+
+        return Waitlist.Unsubscribe.Response(
+            message: "You've been removed from the waitlist."
+        )
+    }
+
+    // MARK: - Admin Endpoints
+
+    func stats(_ req: Request) async throws -> Waitlist.Stats.Response {
+        let repository = req.services.waitlist
+
+        let total = try await repository.count()
+        let notified = try await repository.countNotified()
+
+        return Waitlist.Stats.Response(
+            total: total,
+            notified: notified,
+            pending: total - notified
+        )
+    }
+
+    func notify(_ req: Request) async throws -> Waitlist.Notify.Response {
+        let repository = req.services.waitlist
+        let entries = try await repository.findUnnotified()
+
+        var sent = 0
+        var failed = 0
+
+        for entry in entries {
+            do {
+                try await req.waitlistNotifier.sendLaunchNotification(to: entry)
+                entry.notifiedAt = Date()
+                try await repository.update(entry)
+                sent += 1
+            } catch {
+                req.logger.error("Failed to notify \(entry.email): \(error)")
+                failed += 1
+            }
+        }
+
+        return Waitlist.Notify.Response(
+            sent: sent,
+            failed: failed,
+            message: "Notification complete. Sent: \(sent), Failed: \(failed)"
+        )
+    }
+}

--- a/Sources/App/Modules/Waitlist/WaitlistModule.swift
+++ b/Sources/App/Modules/Waitlist/WaitlistModule.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct WaitlistModule: ModuleInterface {
+
+    let router = WaitlistRouter()
+
+    func boot(_ app: Application) throws {
+        app.migrations.add(WaitlistMigrations.v1())
+        try router.boot(routes: app.routes)
+    }
+}

--- a/Sources/App/Modules/Waitlist/WaitlistRouter.swift
+++ b/Sources/App/Modules/Waitlist/WaitlistRouter.swift
@@ -1,0 +1,52 @@
+import Vapor
+import VaporToOpenAPI
+
+struct WaitlistRouter: RouteCollection {
+    let controller = WaitlistController()
+
+    func boot(routes: RoutesBuilder) throws {
+        let api = routes
+            .grouped("api")
+            .grouped("waitlist")
+            .groupedOpenAPI(tags: .init(name: "Waitlist", description: "Email waitlist management"))
+
+        // Public endpoints (rate limited via middleware)
+        api
+            .post(use: controller.subscribe)
+            .openAPI(
+                description: "Subscribe an email address to the waitlist. Sends a confirmation email on success. Duplicate emails are handled gracefully.",
+                body: .type(Waitlist.Subscribe.Request.self),
+                response: .type(Waitlist.Subscribe.Response.self)
+            )
+            .response(statusCode: .badRequest, description: "Invalid email format")
+
+        api
+            .get("unsubscribe", ":token", use: controller.unsubscribe)
+            .openAPI(
+                description: "Unsubscribe from the waitlist using the token from the confirmation email.",
+                response: .type(Waitlist.Unsubscribe.Response.self)
+            )
+            .response(statusCode: .notFound, description: "Invalid or expired unsubscribe token")
+
+        // Admin-only endpoints
+        let adminAPI = api
+            .grouped(UserAccountModel.guard())
+            .grouped(EnsureAdminUserMiddleware())
+
+        adminAPI
+            .get("stats", use: controller.stats)
+            .openAPI(
+                description: "Get waitlist statistics including total subscribers, notified count, and pending count. Admin only.",
+                response: .type(Waitlist.Stats.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+
+        adminAPI
+            .post("notify", use: controller.notify)
+            .openAPI(
+                description: "Send launch notification to all unnotified subscribers. Processes sequentially to respect email rate limits. Admin only.",
+                response: .type(Waitlist.Notify.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+    }
+}

--- a/Sources/App/Services/Email/Helpers/Templates.swift
+++ b/Sources/App/Services/Email/Helpers/Templates.swift
@@ -321,4 +321,254 @@ enum Templates {
     </html>
     """
     }
+
+    static func waitlistConfirmation(unsubscribeToken: String, baseURL: String) -> String {
+    """
+    <!DOCTYPE html>
+    <html>
+    <head>
+
+      <meta charset="utf-8">
+      <meta http-equiv="x-ua-compatible" content="ie=edge">
+      <title>Welcome to the Waitlist</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style type="text/css">
+      /**
+       * Google webfonts. Recommended to include the .woff version for cross-client compatibility.
+       */
+      @media screen {
+        @font-face {
+          font-family: 'Source Sans Pro';
+          font-style: normal;
+          font-weight: 400;
+          src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/ODelI1aHBYDBqgeIAH2zlBM0YzuT7MdOe03otPbuUS0.woff) format('woff');
+        }
+        @font-face {
+          font-family: 'Source Sans Pro';
+          font-style: normal;
+          font-weight: 700;
+          src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/toadOcfmlt9b38dHJxOBGFkQc6VGVFSmCnC_l7QZG60.woff) format('woff');
+        }
+      }
+      body,
+      table,
+      td,
+      a {
+        -ms-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%;
+      }
+      table,
+      td {
+        mso-table-rspace: 0pt;
+        mso-table-lspace: 0pt;
+      }
+      a[x-apple-data-detectors] {
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        color: inherit !important;
+        text-decoration: none !important;
+      }
+      div[style*="margin: 16px 0;"] {
+        margin: 0 !important;
+      }
+      body {
+        width: 100% !important;
+        height: 100% !important;
+        padding: 0 !important;
+        margin: 0 !important;
+      }
+      table {
+        border-collapse: collapse !important;
+      }
+      a {
+        color: #1a82e2;
+      }
+      </style>
+
+    </head>
+    <body style="background-color: #e9ecef;">
+
+      <!-- start preheader -->
+     <div class="preheader" style="display: none; max-width: 0; max-height: 0; overflow: hidden; font-size: 1px; line-height: 1px; color: #fff; opacity: 0;">
+    You're on the waitlist!
+     </div>
+      <!-- end preheader -->
+
+      <!-- start body -->
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+
+        <!-- start hero -->
+        <tr>
+          <td align="center" bgcolor="#e9ecef">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+              <tr>
+                <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+                  <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">You're on the Waitlist!</h1>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <!-- end hero -->
+
+        <!-- start copy block -->
+        <tr>
+          <td align="center" bgcolor="#e9ecef">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+
+              <!-- start copy -->
+              <tr>
+                <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+                  <p style="margin: 0;">Thanks for signing up! We'll notify you when the app is ready to launch.</p>
+                </td>
+              </tr>
+              <!-- end copy -->
+
+              <!-- start footer -->
+              <tr>
+                <td align="center" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 12px; line-height: 20px; color: #666666;">
+                  <p style="margin: 0;">If you didn't sign up for this waitlist, you can <a href="\(baseURL)/api/waitlist/unsubscribe/\(unsubscribeToken)" style="color: #666666;">unsubscribe here</a>.</p>
+                </td>
+              </tr>
+              <!-- end footer -->
+
+            </table>
+          </td>
+        </tr>
+        <!-- end copy block -->
+
+      </table>
+      <!-- end body -->
+
+    </body>
+    </html>
+    """
+    }
+
+    static func waitlistLaunchNotification(unsubscribeToken: String, baseURL: String) -> String {
+    """
+    <!DOCTYPE html>
+    <html>
+    <head>
+
+      <meta charset="utf-8">
+      <meta http-equiv="x-ua-compatible" content="ie=edge">
+      <title>We're Live!</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style type="text/css">
+      /**
+       * Google webfonts. Recommended to include the .woff version for cross-client compatibility.
+       */
+      @media screen {
+        @font-face {
+          font-family: 'Source Sans Pro';
+          font-style: normal;
+          font-weight: 400;
+          src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/ODelI1aHBYDBqgeIAH2zlBM0YzuT7MdOe03otPbuUS0.woff) format('woff');
+        }
+        @font-face {
+          font-family: 'Source Sans Pro';
+          font-style: normal;
+          font-weight: 700;
+          src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/toadOcfmlt9b38dHJxOBGFkQc6VGVFSmCnC_l7QZG60.woff) format('woff');
+        }
+      }
+      body,
+      table,
+      td,
+      a {
+        -ms-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%;
+      }
+      table,
+      td {
+        mso-table-rspace: 0pt;
+        mso-table-lspace: 0pt;
+      }
+      a[x-apple-data-detectors] {
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        color: inherit !important;
+        text-decoration: none !important;
+      }
+      div[style*="margin: 16px 0;"] {
+        margin: 0 !important;
+      }
+      body {
+        width: 100% !important;
+        height: 100% !important;
+        padding: 0 !important;
+        margin: 0 !important;
+      }
+      table {
+        border-collapse: collapse !important;
+      }
+      a {
+        color: #1a82e2;
+      }
+      </style>
+
+    </head>
+    <body style="background-color: #e9ecef;">
+
+      <!-- start preheader -->
+     <div class="preheader" style="display: none; max-width: 0; max-height: 0; overflow: hidden; font-size: 1px; line-height: 1px; color: #fff; opacity: 0;">
+    The app is now live!
+     </div>
+      <!-- end preheader -->
+
+      <!-- start body -->
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+
+        <!-- start hero -->
+        <tr>
+          <td align="center" bgcolor="#e9ecef">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+              <tr>
+                <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+                  <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">We're Live!</h1>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <!-- end hero -->
+
+        <!-- start copy block -->
+        <tr>
+          <td align="center" bgcolor="#e9ecef">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+
+              <!-- start copy -->
+              <tr>
+                <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+                  <p style="margin: 0;">Great news! The app is now available. Thank you for your patience!</p>
+                </td>
+              </tr>
+              <!-- end copy -->
+
+              <!-- start footer -->
+              <tr>
+                <td align="center" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 12px; line-height: 20px; color: #666666;">
+                  <p style="margin: 0;"><a href="\(baseURL)/api/waitlist/unsubscribe/\(unsubscribeToken)" style="color: #666666;">Unsubscribe</a></p>
+                </td>
+              </tr>
+              <!-- end footer -->
+
+            </table>
+          </td>
+        </tr>
+        <!-- end copy block -->
+
+      </table>
+      <!-- end body -->
+
+    </body>
+    </html>
+    """
+    }
 }

--- a/Sources/App/Services/Email/Helpers/WaitlistNotifier.swift
+++ b/Sources/App/Services/Email/Helpers/WaitlistNotifier.swift
@@ -1,0 +1,61 @@
+import Vapor
+
+struct WaitlistNotifier {
+    let application: Application
+
+    func sendConfirmation(to entry: WaitlistEntryModel) async throws {
+        let baseURL = try application.configuration.security.baseURL
+
+        let content = BrevoMail(
+            sender: .init(
+                name: "Sender",
+                email: "noreply@sender.com"
+            ),
+            to: [.init(
+                name: entry.email,
+                email: entry.email
+            )],
+            subject: "You're on the waitlist!",
+            htmlContent: Templates.waitlistConfirmation(
+                unsubscribeToken: entry.unsubscribeToken,
+                baseURL: baseURL
+            )
+        )
+
+        try await application.serviceCache.emailService.send(content)
+    }
+
+    func sendLaunchNotification(to entry: WaitlistEntryModel) async throws {
+        let baseURL = try application.configuration.security.baseURL
+
+        let content = BrevoMail(
+            sender: .init(
+                name: "Sender",
+                email: "noreply@sender.com"
+            ),
+            to: [.init(
+                name: entry.email,
+                email: entry.email
+            )],
+            subject: "We're live! The app is ready",
+            htmlContent: Templates.waitlistLaunchNotification(
+                unsubscribeToken: entry.unsubscribeToken,
+                baseURL: baseURL
+            )
+        )
+
+        try await application.serviceCache.emailService.send(content)
+    }
+}
+
+extension Application {
+    var waitlistNotifier: WaitlistNotifier {
+        .init(application: self)
+    }
+}
+
+extension Request {
+    var waitlistNotifier: WaitlistNotifier {
+        .init(application: application)
+    }
+}

--- a/docs/planning/work/waitlist-email/.exploration-cache.json
+++ b/docs/planning/work/waitlist-email/.exploration-cache.json
@@ -1,0 +1,96 @@
+{
+  "slug": "waitlist-email",
+  "type": "feature",
+  "explored_at": "2025-12-03T12:00:00Z",
+  "platform": "backend",
+  "language": "Swift",
+  "architecture": "Vapor Modular Architecture",
+  "affected_files": [
+    {
+      "path": "Sources/App/Modules/Waitlist/",
+      "component": "WaitlistModule",
+      "purpose": "New module to be created for waitlist functionality (signup, unsubscribe, bulk notify)",
+      "dependencies": ["EmailService", "Fluent", "RateLimitMiddleware"]
+    },
+    {
+      "path": "Sources/App/Services/Email/BrevoClient.swift",
+      "component": "EmailService",
+      "purpose": "Existing Brevo email client for sending confirmation emails",
+      "dependencies": ["Brevo API"]
+    },
+    {
+      "path": "Sources/App/Services/Email/Helpers/Templates.swift",
+      "component": "EmailTemplates",
+      "purpose": "Add new waitlist confirmation template",
+      "dependencies": []
+    },
+    {
+      "path": "Sources/App/configure.swift",
+      "component": "AppConfiguration",
+      "purpose": "Register new Waitlist module",
+      "dependencies": ["WaitlistModule"]
+    }
+  ],
+  "components": [
+    {
+      "name": "WaitlistModule",
+      "type": "Vapor Module",
+      "location": "Sources/App/Modules/Waitlist/",
+      "integration_points": ["EmailService", "Database"]
+    },
+    {
+      "name": "WaitlistModel",
+      "type": "Fluent Model",
+      "location": "Sources/App/Modules/Waitlist/Database/Models/",
+      "integration_points": ["Database"]
+    },
+    {
+      "name": "WaitlistRouter",
+      "type": "RouteCollection",
+      "location": "Sources/App/Modules/Waitlist/",
+      "integration_points": ["WaitlistController"]
+    },
+    {
+      "name": "WaitlistController",
+      "type": "Controller",
+      "location": "Sources/App/Modules/Waitlist/",
+      "integration_points": ["WaitlistRepository", "EmailService"]
+    },
+    {
+      "name": "EmailService",
+      "type": "Service",
+      "location": "Sources/App/Services/Email/",
+      "integration_points": ["Brevo API"]
+    }
+  ],
+  "patterns": {
+    "state_management": "Database via Fluent ORM",
+    "error_handling": "Vapor error middleware with structured responses",
+    "testing": "Swift Testing framework",
+    "architecture_style": "Module-based with Repository pattern"
+  },
+  "similar_implementations": [
+    {
+      "feature": "User Module",
+      "file": "Sources/App/Modules/User/",
+      "pattern": "Complete module structure with model, router, controller, repository",
+      "relevance": "Follow same structure for Waitlist module"
+    },
+    {
+      "feature": "Auth Email Verification",
+      "file": "Sources/App/Services/Email/Helpers/EmailVerifier.swift",
+      "pattern": "Email sending with templates",
+      "relevance": "Pattern for sending waitlist confirmation emails"
+    },
+    {
+      "feature": "Auth Migrations",
+      "file": "Sources/App/Modules/Auth/Database/Migrations/AuthMigrations.swift",
+      "pattern": "Database migration patterns",
+      "relevance": "Follow for Waitlist table migration"
+    }
+  ],
+  "dependencies": {
+    "internal": ["EmailService", "DatabaseModelInterface", "ModuleInterface"],
+    "external": ["Vapor", "Fluent", "Brevo API"]
+  }
+}

--- a/docs/planning/work/waitlist-email/TASK-001-database-model.md
+++ b/docs/planning/work/waitlist-email/TASK-001-database-model.md
@@ -1,0 +1,109 @@
+## TASK-001: Create WaitlistEntry Database Model & Migration
+
+---
+**Status:** OPEN
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 1
+**Depends On:** None
+---
+
+### Overview
+
+Create the Fluent database model and migration for storing waitlist email entries. This is the foundation for all waitlist functionality.
+
+**Files:**
+- `Sources/App/Modules/Waitlist/Database/Models/WaitlistEntryModel.swift` (create)
+- `Sources/App/Modules/Waitlist/Database/Migrations/WaitlistMigrations.swift` (create)
+
+### Implementation Steps
+
+**Commit 1: Create WaitlistEntryModel and Migration**
+- [ ] Create directory structure: `Sources/App/Modules/Waitlist/Database/Models/` and `Sources/App/Modules/Waitlist/Database/Migrations/`
+- [ ] Create `WaitlistEntryModel.swift` with fields: id (UUID), email (String), unsubscribeToken (String), createdAt (Date), notifiedAt (Date?)
+- [ ] Add FieldKeys struct with v1 nested struct for versioned field names
+- [ ] Conform to `DatabaseModelInterface` and `@unchecked Sendable`
+- [ ] Create `WaitlistMigrations.swift` with v1 AsyncMigration
+- [ ] Add unique constraint on email column
+- [ ] Add index on unsubscribeToken for fast lookup
+
+### Code Example
+
+```swift
+// Pattern from UserAccountModel.swift
+// Sources/App/Modules/User/Database/Models/UserAccountModel.swift:1-66
+
+final class WaitlistEntryModel: @unchecked Sendable, DatabaseModelInterface {
+    typealias Module = WaitlistModule
+    static var schema: String { "waitlist_entries" }
+
+    @ID() var id: UUID?
+    @Field(key: FieldKeys.v1.email) var email: String
+    @Field(key: FieldKeys.v1.unsubscribeToken) var unsubscribeToken: String
+    @Timestamp(key: FieldKeys.v1.createdAt, on: .create) var createdAt: Date?
+    @OptionalField(key: FieldKeys.v1.notifiedAt) var notifiedAt: Date?
+
+    init() { }
+
+    init(id: UUID? = nil, email: String, unsubscribeToken: String = UUID().uuidString) {
+        self.id = id
+        self.email = email
+        self.unsubscribeToken = unsubscribeToken
+    }
+}
+
+extension WaitlistEntryModel {
+    struct FieldKeys {
+        struct v1 {
+            static var email: FieldKey { "email" }
+            static var unsubscribeToken: FieldKey { "unsubscribe_token" }
+            static var createdAt: FieldKey { "created_at" }
+            static var notifiedAt: FieldKey { "notified_at" }
+        }
+    }
+}
+```
+
+```swift
+// Migration pattern from UserMigrations.swift
+// Sources/App/Modules/User/Database/Migrations/UserMigrations.swift:4-29
+
+enum WaitlistMigrations {
+    struct v1: AsyncMigration {
+        func prepare(on db: Database) async throws {
+            try await db.schema(WaitlistEntryModel.schema)
+                .id()
+                .field(WaitlistEntryModel.FieldKeys.v1.email, .string, .required)
+                .field(WaitlistEntryModel.FieldKeys.v1.unsubscribeToken, .string, .required)
+                .field(WaitlistEntryModel.FieldKeys.v1.createdAt, .datetime)
+                .field(WaitlistEntryModel.FieldKeys.v1.notifiedAt, .datetime)
+                .unique(on: WaitlistEntryModel.FieldKeys.v1.email)
+                .unique(on: WaitlistEntryModel.FieldKeys.v1.unsubscribeToken)
+                .create()
+        }
+
+        func revert(on db: Database) async throws {
+            try await db.schema(WaitlistEntryModel.schema).delete()
+        }
+    }
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] Model file compiles without errors
+- [ ] Migration file compiles without errors
+- [ ] Schema includes unique constraint on email
+
+### Verification
+
+```bash
+swift build
+```
+
+### Notes
+
+- Use `@OptionalField` for `notifiedAt` since it's null until notification is sent
+- The `unsubscribeToken` is auto-generated as UUID in the initializer
+- Follow exact pattern from UserAccountModel for consistency

--- a/docs/planning/work/waitlist-email/TASK-002-repository.md
+++ b/docs/planning/work/waitlist-email/TASK-002-repository.md
@@ -1,0 +1,123 @@
+## TASK-002: Create WaitlistRepository
+
+---
+**Status:** OPEN
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 1
+**Depends On:** TASK-001
+---
+
+### Overview
+
+Create the repository protocol and database implementation for waitlist data access. This provides the data layer abstraction used by the controller.
+
+**Files:**
+- `Sources/App/Modules/Waitlist/Repositories/WaitlistRepository.swift` (create)
+
+### Implementation Steps
+
+**Commit 1: Create WaitlistRepository protocol and implementation**
+- [ ] Create directory: `Sources/App/Modules/Waitlist/Repositories/`
+- [ ] Define `WaitlistRepository` protocol with methods: create, findByEmail, findByToken, delete, all, findUnnotified, update
+- [ ] Create `DatabaseWaitlistRepository` struct conforming to protocol
+- [ ] Implement all repository methods using Fluent queries
+- [ ] Add `Application.Repositories` extension for `waitlist` accessor
+- [ ] Add `Request.Services` extension for request-scoped access
+
+### Code Example
+
+```swift
+// Pattern from UserRepository.swift
+// Sources/App/Modules/User/Repositories/UserRepository.swift:1-50
+
+import Fluent
+import Vapor
+
+protocol WaitlistRepository: Repository {
+    func find(id: UUID) async throws -> WaitlistEntryModel?
+    func find(email: String) async throws -> WaitlistEntryModel?
+    func find(token: String) async throws -> WaitlistEntryModel?
+    func create(_ model: WaitlistEntryModel) async throws
+    func delete(_ model: WaitlistEntryModel) async throws
+    func all() async throws -> [WaitlistEntryModel]
+    func findUnnotified() async throws -> [WaitlistEntryModel]
+    func update(_ model: WaitlistEntryModel) async throws
+    func count() async throws -> Int
+    func countNotified() async throws -> Int
+}
+
+struct DatabaseWaitlistRepository: WaitlistRepository, DatabaseRepository {
+    typealias Model = WaitlistEntryModel
+    let database: Database
+
+    func find(id: UUID) async throws -> WaitlistEntryModel? {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$id == id)
+            .first()
+    }
+
+    func find(email: String) async throws -> WaitlistEntryModel? {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$email == email)
+            .first()
+    }
+
+    func find(token: String) async throws -> WaitlistEntryModel? {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$unsubscribeToken == token)
+            .first()
+    }
+
+    func create(_ model: WaitlistEntryModel) async throws {
+        try await model.create(on: database)
+    }
+
+    func delete(_ model: WaitlistEntryModel) async throws {
+        try await model.delete(on: database)
+    }
+
+    func all() async throws -> [WaitlistEntryModel] {
+        try await WaitlistEntryModel.query(on: database).all()
+    }
+
+    func findUnnotified() async throws -> [WaitlistEntryModel] {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$notifiedAt == nil)
+            .all()
+    }
+
+    func update(_ model: WaitlistEntryModel) async throws {
+        try await model.update(on: database)
+    }
+
+    func count() async throws -> Int {
+        try await WaitlistEntryModel.query(on: database).count()
+    }
+
+    func countNotified() async throws -> Int {
+        try await WaitlistEntryModel.query(on: database)
+            .filter(\.$notifiedAt != nil)
+            .count()
+    }
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] Protocol defines all needed methods
+- [ ] Database implementation compiles
+- [ ] Extensions for Application and Request added
+
+### Verification
+
+```bash
+swift build
+```
+
+### Notes
+
+- `findUnnotified()` filters where notifiedAt is nil - used for bulk notifications
+- `countNotified()` and `count()` used for stats endpoint
+- Follow UserRepository pattern for consistency with codebase

--- a/docs/planning/work/waitlist-email/TASK-003-module-setup.md
+++ b/docs/planning/work/waitlist-email/TASK-003-module-setup.md
@@ -1,0 +1,89 @@
+## TASK-003: Create WaitlistModule and Register
+
+---
+**Status:** OPEN
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 1
+**Depends On:** TASK-001, TASK-002
+---
+
+### Overview
+
+Create the WaitlistModule conforming to ModuleInterface and register it in the application setup. This wires up migrations and prepares for route registration.
+
+**Files:**
+- `Sources/App/Modules/Waitlist/WaitlistModule.swift` (create)
+- `Sources/App/Entrypoint/Application-Setup.swift` (modify)
+
+### Implementation Steps
+
+**Commit 1: Create WaitlistModule and register in Application-Setup**
+- [ ] Create `WaitlistModule.swift` conforming to `ModuleInterface`
+- [ ] Add migration registration in `boot()` method
+- [ ] Create placeholder `WaitlistRouter` (empty for now, to be implemented in TASK-006)
+- [ ] Add `WaitlistModule()` to modules array in `Application-Setup.swift:83-89`
+
+### Code Example
+
+```swift
+// Pattern from UserModule.swift
+// Sources/App/Modules/User/UserModule.swift:1-16
+
+import Vapor
+
+struct WaitlistModule: ModuleInterface {
+    let router = WaitlistRouter()
+
+    func boot(_ app: Application) throws {
+        app.migrations.add(WaitlistMigrations.v1())
+        try router.boot(routes: app.routes)
+    }
+}
+```
+
+```swift
+// Placeholder router (to be completed in TASK-006)
+import Vapor
+
+struct WaitlistRouter: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        // Routes will be added in TASK-006
+    }
+}
+```
+
+```swift
+// Modify Application-Setup.swift:82-89
+func setupModules() throws {
+    let modules: [ModuleInterface] = [
+        UserModule(),
+        AuthModule(),
+        FrontendModule(),
+        RulesGenerationModule(),
+        CacheAdminModule(),
+        WaitlistModule(),  // Add this line
+    ]
+    // ...
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] Module conforms to ModuleInterface
+- [ ] Module is registered in setupModules()
+- [ ] Migration runs on app startup
+
+### Verification
+
+```bash
+swift build
+swift run App migrate --env development
+```
+
+### Notes
+
+- Router is a placeholder for now - actual routes added in Phase 2
+- Migration will auto-run due to `autoMigrate()` in configure.swift
+- Keep module structure consistent with User, Auth modules

--- a/docs/planning/work/waitlist-email/TASK-004-dto-models.md
+++ b/docs/planning/work/waitlist-email/TASK-004-dto-models.md
@@ -1,0 +1,92 @@
+## TASK-004: Create Request/Response DTOs
+
+---
+**Status:** OPEN
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 1
+**Depends On:** TASK-001
+---
+
+### Overview
+
+Create the Data Transfer Objects (DTOs) for waitlist API requests and responses. These define the API contract for subscribe, unsubscribe, stats, and notify endpoints.
+
+**Files:**
+- `Sources/App/Modules/Waitlist/Models/Waitlist+Model.swift` (create)
+
+### Implementation Steps
+
+**Commit 1: Create Waitlist DTOs**
+- [ ] Create directory: `Sources/App/Modules/Waitlist/Models/`
+- [ ] Define `Waitlist` namespace enum
+- [ ] Create `Subscribe.Request` with email field and validation
+- [ ] Create `Subscribe.Response` with success message
+- [ ] Create `Unsubscribe.Response` with confirmation
+- [ ] Create `Stats.Response` with total, notified, pending counts
+- [ ] Create `Notify.Response` with notification results
+
+### Code Example
+
+```swift
+// Pattern from User+Model.swift style DTOs
+import Vapor
+
+enum Waitlist {
+    enum Subscribe {
+        struct Request: Content, Validatable {
+            let email: String
+
+            static func validations(_ validations: inout Validations) {
+                validations.add("email", as: String.self, is: .email)
+            }
+        }
+
+        struct Response: Content {
+            let message: String
+            let email: String
+        }
+    }
+
+    enum Unsubscribe {
+        struct Response: Content {
+            let message: String
+        }
+    }
+
+    enum Stats {
+        struct Response: Content {
+            let total: Int
+            let notified: Int
+            let pending: Int
+        }
+    }
+
+    enum Notify {
+        struct Response: Content {
+            let sent: Int
+            let failed: Int
+            let message: String
+        }
+    }
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] All DTOs conform to Content
+- [ ] Subscribe.Request has email validation
+- [ ] Response types cover all endpoints
+
+### Verification
+
+```bash
+swift build
+```
+
+### Notes
+
+- Use Vapor's built-in `Validatable` protocol for email validation
+- Keep responses simple - can be extended later if needed
+- Stats response provides all counts admin dashboard might need

--- a/docs/planning/work/waitlist-email/TASK-005-email-templates.md
+++ b/docs/planning/work/waitlist-email/TASK-005-email-templates.md
@@ -1,0 +1,139 @@
+## TASK-005: Add Waitlist Email Templates
+
+---
+**Status:** OPEN
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 1
+**Depends On:** None
+---
+
+### Overview
+
+Add HTML email templates for waitlist confirmation and launch notification emails. Both templates include an unsubscribe link in the footer.
+
+**Files:**
+- `Sources/App/Services/Email/Helpers/Templates.swift` (modify)
+
+### Implementation Steps
+
+**Commit 1: Add waitlist email templates**
+- [ ] Add `waitlistConfirmation(unsubscribeToken:baseURL:)` static method
+- [ ] Add `waitlistLaunchNotification(unsubscribeToken:baseURL:)` static method
+- [ ] Include unsubscribe link in footer of both templates
+- [ ] Use same HTML structure as existing verifyEmail template
+- [ ] Keep content simple/placeholder per requirements
+
+### Code Example
+
+```swift
+// Add to Templates.swift after existing templates
+// Sources/App/Services/Email/Helpers/Templates.swift
+
+static func waitlistConfirmation(unsubscribeToken: String, baseURL: String) -> String {
+    """
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="x-ua-compatible" content="ie=edge">
+      <title>Welcome to the Waitlist</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style type="text/css">
+      /* Same styles as verifyEmail template */
+      body { width: 100% !important; padding: 0 !important; margin: 0 !important; }
+      </style>
+    </head>
+    <body style="background-color: #e9ecef;">
+      <div class="preheader" style="display: none;">You're on the waitlist!</div>
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+          <td align="center" bgcolor="#e9ecef">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+              <tr>
+                <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+                  <h1 style="margin: 0; font-size: 32px; font-weight: 700;">You're on the Waitlist!</h1>
+                </td>
+              </tr>
+              <tr>
+                <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+                  <p>Thanks for signing up! We'll notify you when the app is ready to launch.</p>
+                </td>
+              </tr>
+              <tr>
+                <td align="center" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 12px; color: #666;">
+                  <a href="\\(baseURL)/api/waitlist/unsubscribe/\\(unsubscribeToken)" style="color: #666;">Unsubscribe from this list</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>
+    </html>
+    """
+}
+
+static func waitlistLaunchNotification(unsubscribeToken: String, baseURL: String) -> String {
+    """
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="x-ua-compatible" content="ie=edge">
+      <title>We're Live!</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style type="text/css">
+      body { width: 100% !important; padding: 0 !important; margin: 0 !important; }
+      </style>
+    </head>
+    <body style="background-color: #e9ecef;">
+      <div class="preheader" style="display: none;">The app is now live!</div>
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+          <td align="center" bgcolor="#e9ecef">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+              <tr>
+                <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+                  <h1 style="margin: 0; font-size: 32px; font-weight: 700;">We're Live!</h1>
+                </td>
+              </tr>
+              <tr>
+                <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+                  <p>Great news! The app is now available. Thank you for your patience!</p>
+                </td>
+              </tr>
+              <tr>
+                <td align="center" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 12px; color: #666;">
+                  <a href="\\(baseURL)/api/waitlist/unsubscribe/\\(unsubscribeToken)" style="color: #666;">Unsubscribe</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>
+    </html>
+    """
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] Both templates render valid HTML
+- [ ] Unsubscribe link included in footer
+- [ ] String interpolation works for token and baseURL
+
+### Verification
+
+```bash
+swift build
+```
+
+### Notes
+
+- Keep content simple as requested - user will refine later
+- Unsubscribe URL format: `{baseURL}/api/waitlist/unsubscribe/{token}`
+- Escape backslashes in Swift string interpolation: `\\(variable)`
+- Can copy full CSS from existing templates for better formatting

--- a/docs/planning/work/waitlist-email/TASK-006-waitlist-notifier.md
+++ b/docs/planning/work/waitlist-email/TASK-006-waitlist-notifier.md
@@ -1,0 +1,114 @@
+## TASK-006: Create WaitlistNotifier Helper
+
+---
+**Status:** OPEN
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 1
+**Depends On:** TASK-005
+---
+
+### Overview
+
+Create a helper struct for sending waitlist-related emails (confirmation and launch notification). Follows the same pattern as EmailVerifier.
+
+**Files:**
+- `Sources/App/Services/Email/Helpers/WaitlistNotifier.swift` (create)
+
+### Implementation Steps
+
+**Commit 1: Create WaitlistNotifier**
+- [ ] Create `WaitlistNotifier.swift` in Email/Helpers directory
+- [ ] Add `sendConfirmation(to:)` method for waitlist signup confirmation
+- [ ] Add `sendLaunchNotification(to:)` method for launch announcement
+- [ ] Add Application and Request extensions for easy access
+- [ ] Use existing EmailService for sending
+
+### Code Example
+
+```swift
+// Pattern from EmailVerifier.swift
+// Sources/App/Services/Email/Helpers/EmailVerifier.swift:1-55
+
+import Vapor
+
+struct WaitlistNotifier {
+    let application: Application
+
+    func sendConfirmation(to entry: WaitlistEntryModel) async throws {
+        let baseURL = try application.configuration.security.baseURL
+
+        let content = BrevoMail(
+            sender: .init(
+                name: "Project Rulebook",
+                email: "noreply@projectrulebook.com"
+            ),
+            to: [.init(
+                name: entry.email,
+                email: entry.email
+            )],
+            subject: "You're on the waitlist!",
+            htmlContent: Templates.waitlistConfirmation(
+                unsubscribeToken: entry.unsubscribeToken,
+                baseURL: baseURL
+            )
+        )
+
+        try await application.serviceCache.emailService.send(content)
+    }
+
+    func sendLaunchNotification(to entry: WaitlistEntryModel) async throws {
+        let baseURL = try application.configuration.security.baseURL
+
+        let content = BrevoMail(
+            sender: .init(
+                name: "Project Rulebook",
+                email: "noreply@projectrulebook.com"
+            ),
+            to: [.init(
+                name: entry.email,
+                email: entry.email
+            )],
+            subject: "We're live! The app is ready",
+            htmlContent: Templates.waitlistLaunchNotification(
+                unsubscribeToken: entry.unsubscribeToken,
+                baseURL: baseURL
+            )
+        )
+
+        try await application.serviceCache.emailService.send(content)
+    }
+}
+
+extension Application {
+    var waitlistNotifier: WaitlistNotifier {
+        .init(application: self)
+    }
+}
+
+extension Request {
+    var waitlistNotifier: WaitlistNotifier {
+        .init(application: application)
+    }
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] Both email methods compile
+- [ ] Extensions provide easy access from Application and Request
+- [ ] Uses existing EmailService infrastructure
+
+### Verification
+
+```bash
+swift build
+```
+
+### Notes
+
+- Sender email should be configured - using placeholder for now
+- Uses `application.serviceCache.emailService` for sending (same as EmailVerifier)
+- baseURL comes from security configuration
+- Entry contains unsubscribeToken for template

--- a/docs/planning/work/waitlist-email/TASK-007-rate-limiting.md
+++ b/docs/planning/work/waitlist-email/TASK-007-rate-limiting.md
@@ -1,0 +1,121 @@
+## TASK-007: Add Waitlist Rate Limiting
+
+---
+**Status:** OPEN
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 1
+**Depends On:** None
+---
+
+### Overview
+
+Add waitlist-specific rate limiting to prevent spam abuse on the public signup endpoint. Configure moderate limits (10 requests/hour per IP).
+
+**Files:**
+- `Sources/App/Middlewares/Security/RateLimit/RateLimitTypes.swift` (modify)
+- `Sources/App/Middlewares/Security/RateLimit/RateLimitMiddleware.swift` (modify)
+
+### Implementation Steps
+
+**Commit 1: Add waitlist rate limit type and path detection**
+- [ ] Add `waitlist` case to `RateLimitType` enum with rawValue "waitlist"
+- [ ] Add `waitlistLimit` and `waitlistWindow` properties to `RateLimitConfiguration` (if exists) or use inline values
+- [ ] Add path detection for `/api/waitlist` in `determineRateLimit()` method
+- [ ] Place path check BEFORE the general `/api/` catch-all
+
+### Code Example
+
+```swift
+// Add to RateLimitTypes.swift:20-82
+// Sources/App/Middlewares/Security/RateLimit/RateLimitTypes.swift
+
+enum RateLimitType: String, CaseIterable {
+    case imageAnalysis = "image_analysis"
+    case rulesGeneration = "rules_generation"
+    case admin = "admin"
+    case api = "api"
+    case general = "general"
+    case waitlist = "waitlist"  // Add this case
+}
+```
+
+```swift
+// Add to RateLimitMiddleware.swift:167-211
+// Sources/App/Middlewares/Security/RateLimit/RateLimitMiddleware.swift
+
+private func determineRateLimit(for request: Request) -> RateLimitInfo {
+    let path = request.url.path
+
+    // AI-specific endpoints
+    if path.contains("/api/rules-generation/game-box-analysis") {
+        return RateLimitInfo(
+            type: .imageAnalysis,
+            maxRequests: configuration.imageAnalysisLimit,
+            windowSeconds: configuration.imageAnalysisWindow
+        )
+    }
+
+    if path.contains("/api/rules-generation/rules-summary") {
+        return RateLimitInfo(
+            type: .rulesGeneration,
+            maxRequests: configuration.rulesGenerationLimit,
+            windowSeconds: configuration.rulesGenerationWindow
+        )
+    }
+
+    // Waitlist endpoint - ADD THIS BLOCK before admin/api
+    if path.hasPrefix("/api/waitlist") {
+        return RateLimitInfo(
+            type: .waitlist,
+            maxRequests: 10,  // 10 requests per hour
+            windowSeconds: 3600  // 1 hour window
+        )
+    }
+
+    // Admin endpoints
+    if path.contains("/api/admin/") {
+        return RateLimitInfo(
+            type: .admin,
+            maxRequests: configuration.adminLimit,
+            windowSeconds: configuration.adminWindow
+        )
+    }
+
+    // API endpoints (catch-all)
+    if path.hasPrefix("/api/") {
+        return RateLimitInfo(
+            type: .api,
+            maxRequests: configuration.apiLimit,
+            windowSeconds: configuration.apiWindow
+        )
+    }
+
+    // General web endpoints
+    return RateLimitInfo(
+        type: .general,
+        maxRequests: configuration.generalLimit,
+        windowSeconds: configuration.generalWindow
+    )
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] RateLimitType includes `waitlist` case
+- [ ] `/api/waitlist` requests use waitlist-specific limits
+- [ ] Path check is before general `/api/` catch-all
+
+### Verification
+
+```bash
+swift build
+```
+
+### Notes
+
+- 10 requests/hour is a reasonable limit for legitimate signups
+- Must be placed BEFORE the `/api/` catch-all or it will never match
+- Using inline values (10, 3600) for simplicity - can be moved to configuration later
+- This protects against automated spam while allowing real users

--- a/docs/planning/work/waitlist-email/TASK-008-public-endpoints.md
+++ b/docs/planning/work/waitlist-email/TASK-008-public-endpoints.md
@@ -1,0 +1,148 @@
+## TASK-008: Implement Public Endpoints (Subscribe & Unsubscribe)
+
+---
+**Status:** COMPLETE
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 2
+**Depends On:** TASK-003, TASK-004, TASK-005, TASK-006, TASK-007
+---
+
+### Overview
+
+Implement the public-facing API endpoints for subscribing to the waitlist and unsubscribing. These endpoints are publicly accessible (no auth required) but rate-limited.
+
+**Files:**
+- `Sources/App/Modules/Waitlist/WaitlistRouter.swift` (modify - replace placeholder)
+- `Sources/App/Modules/Waitlist/WaitlistController.swift` (create)
+
+### Implementation Steps
+
+**Commit 1: Create WaitlistController and public routes**
+- [x] Create `WaitlistController.swift` with `subscribe()` and `unsubscribe()` methods
+- [x] Update `WaitlistRouter.swift` with route definitions
+- [x] `POST /api/waitlist` - Validate email, check duplicate, create entry, send confirmation
+- [x] `GET /api/waitlist/unsubscribe/:token` - Find by token, delete entry
+- [x] Add OpenAPI documentation for both endpoints
+- [x] Handle duplicate emails gracefully (return success without creating duplicate)
+
+### Code Example
+
+```swift
+// Sources/App/Modules/Waitlist/WaitlistController.swift
+import Vapor
+
+struct WaitlistController {
+
+    func subscribe(_ req: Request) async throws -> Waitlist.Subscribe.Response {
+        // Validate request
+        try Waitlist.Subscribe.Request.validate(content: req)
+        let subscribeRequest = try req.content.decode(Waitlist.Subscribe.Request.self)
+
+        let repository = req.application.serviceCache.waitlistRepository
+
+        // Check for existing entry (idempotent)
+        if let existing = try await repository.find(email: subscribeRequest.email) {
+            return Waitlist.Subscribe.Response(
+                message: "You're already on the waitlist!",
+                email: existing.email
+            )
+        }
+
+        // Create new entry
+        let entry = WaitlistEntryModel(email: subscribeRequest.email)
+        try await repository.create(entry)
+
+        // Send confirmation email (fire and forget - don't fail on email error)
+        Task {
+            do {
+                try await req.waitlistNotifier.sendConfirmation(to: entry)
+            } catch {
+                req.logger.error("Failed to send waitlist confirmation email: \(error)")
+            }
+        }
+
+        return Waitlist.Subscribe.Response(
+            message: "Thanks for joining the waitlist!",
+            email: entry.email
+        )
+    }
+
+    func unsubscribe(_ req: Request) async throws -> Waitlist.Unsubscribe.Response {
+        guard let token = req.parameters.get("token") else {
+            throw Abort(.badRequest, reason: "Missing unsubscribe token")
+        }
+
+        let repository = req.application.serviceCache.waitlistRepository
+
+        guard let entry = try await repository.find(token: token) else {
+            throw Abort(.notFound, reason: "Invalid or expired unsubscribe link")
+        }
+
+        try await repository.delete(entry)
+
+        return Waitlist.Unsubscribe.Response(
+            message: "You've been removed from the waitlist."
+        )
+    }
+}
+```
+
+```swift
+// Sources/App/Modules/Waitlist/WaitlistRouter.swift
+import Vapor
+import VaporToOpenAPI
+
+struct WaitlistRouter: RouteCollection {
+    let controller = WaitlistController()
+
+    func boot(routes: RoutesBuilder) throws {
+        let api = routes
+            .grouped("api")
+            .grouped("waitlist")
+            .groupedOpenAPI(tags: .init(name: "Waitlist", description: "Email waitlist management"))
+
+        // Public endpoints (rate limited via middleware)
+        api.post(use: controller.subscribe)
+            .openAPI(
+                description: "Subscribe an email address to the waitlist. Sends a confirmation email on success.",
+                body: .type(Waitlist.Subscribe.Request.self),
+                response: .type(Waitlist.Subscribe.Response.self)
+            )
+
+        api.get("unsubscribe", ":token", use: controller.unsubscribe)
+            .openAPI(
+                description: "Unsubscribe from the waitlist using the token from the email.",
+                response: .type(Waitlist.Unsubscribe.Response.self)
+            )
+            .response(statusCode: .notFound, description: "Invalid or expired token")
+    }
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] POST /api/waitlist creates entry and sends email
+- [ ] Duplicate email returns 200 (idempotent)
+- [ ] Invalid email returns 400 validation error
+- [ ] GET /api/waitlist/unsubscribe/:token deletes entry
+- [ ] Invalid token returns 404
+- [ ] OpenAPI documentation included
+
+### Verification
+
+```bash
+swift build
+# Manual test:
+curl -X POST http://localhost:8080/api/waitlist \
+  -H "Content-Type: application/json" \
+  -d '{"email": "test@example.com"}'
+```
+
+### Notes
+
+- Email sending is fire-and-forget to not block the response
+- Repository access via `req.application.serviceCache.waitlistRepository` (need to add this extension)
+- Duplicate handling returns success - user doesn't need to know they're already subscribed
+- Token parameter uses Vapor's parameter extraction: `req.parameters.get("token")`

--- a/docs/planning/work/waitlist-email/TASK-009-admin-endpoints.md
+++ b/docs/planning/work/waitlist-email/TASK-009-admin-endpoints.md
@@ -1,0 +1,147 @@
+## TASK-009: Implement Admin Endpoints (Stats & Notify)
+
+---
+**Status:** COMPLETE
+**Branch:** feature/waitlist-email
+**Type:** IMPLEMENTATION
+**Phase:** 2
+**Depends On:** TASK-008
+---
+
+### Overview
+
+Implement admin-only endpoints for viewing waitlist statistics and sending bulk launch notifications. These endpoints require JWT authentication and admin privileges.
+
+**Files:**
+- `Sources/App/Modules/Waitlist/WaitlistRouter.swift` (modify)
+- `Sources/App/Modules/Waitlist/WaitlistController.swift` (modify)
+
+### Implementation Steps
+
+**Commit 1: Add admin-protected routes and controller methods**
+- [x] Add `stats()` method to WaitlistController - return total, notified, pending counts
+- [x] Add `notify()` method to WaitlistController - send launch emails to all unnotified
+- [x] Add admin-protected route group in WaitlistRouter using `EnsureAdminUserMiddleware()`
+- [x] `GET /api/waitlist/stats` - Returns waitlist statistics
+- [x] `POST /api/waitlist/notify` - Triggers bulk launch notification
+- [x] Update notifiedAt timestamp after successful email send
+- [x] Add OpenAPI documentation with auth requirements
+
+### Code Example
+
+```swift
+// Add to WaitlistController.swift
+// Sources/App/Modules/Waitlist/WaitlistController.swift
+
+func stats(_ req: Request) async throws -> Waitlist.Stats.Response {
+    let repository = req.application.serviceCache.waitlistRepository
+
+    let total = try await repository.count()
+    let notified = try await repository.countNotified()
+
+    return Waitlist.Stats.Response(
+        total: total,
+        notified: notified,
+        pending: total - notified
+    )
+}
+
+func notify(_ req: Request) async throws -> Waitlist.Notify.Response {
+    let repository = req.application.serviceCache.waitlistRepository
+    let entries = try await repository.findUnnotified()
+
+    var sent = 0
+    var failed = 0
+
+    for entry in entries {
+        do {
+            try await req.waitlistNotifier.sendLaunchNotification(to: entry)
+            entry.notifiedAt = Date()
+            try await repository.update(entry)
+            sent += 1
+        } catch {
+            req.logger.error("Failed to notify \(entry.email): \(error)")
+            failed += 1
+        }
+    }
+
+    return Waitlist.Notify.Response(
+        sent: sent,
+        failed: failed,
+        message: "Notification complete. Sent: \(sent), Failed: \(failed)"
+    )
+}
+```
+
+```swift
+// Update WaitlistRouter.swift to add admin routes
+// Sources/App/Modules/Waitlist/WaitlistRouter.swift
+
+func boot(routes: RoutesBuilder) throws {
+    let api = routes
+        .grouped("api")
+        .grouped("waitlist")
+        .groupedOpenAPI(tags: .init(name: "Waitlist", description: "Email waitlist management"))
+
+    // Public endpoints (existing)
+    api.post(use: controller.subscribe)
+        .openAPI(
+            description: "Subscribe an email address to the waitlist.",
+            body: .type(Waitlist.Subscribe.Request.self),
+            response: .type(Waitlist.Subscribe.Response.self)
+        )
+
+    api.get("unsubscribe", ":token", use: controller.unsubscribe)
+        .openAPI(
+            description: "Unsubscribe from the waitlist using the token from the email.",
+            response: .type(Waitlist.Unsubscribe.Response.self)
+        )
+
+    // Admin-only endpoints (pattern from UserRouter.swift:48-55)
+    let adminAPI = api
+        .grouped(UserAccountModel.guard())
+        .grouped(EnsureAdminUserMiddleware())
+
+    adminAPI.get("stats", use: controller.stats)
+        .openAPI(
+            description: "Get waitlist statistics. Admin only.",
+            response: .type(Waitlist.Stats.Response.self),
+            auth: .bearer(id: "bearerAuth")
+        )
+
+    adminAPI.post("notify", use: controller.notify)
+        .openAPI(
+            description: "Send launch notification to all unnotified subscribers. Admin only.",
+            response: .type(Waitlist.Notify.Response.self),
+            auth: .bearer(id: "bearerAuth")
+        )
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] GET /api/waitlist/stats returns correct counts
+- [ ] POST /api/waitlist/notify sends emails to unnotified entries
+- [ ] notifiedAt is updated after successful send
+- [ ] 401 returned for unauthenticated requests
+- [ ] 401 returned for non-admin users
+- [ ] OpenAPI documentation includes auth requirement
+
+### Verification
+
+```bash
+swift build
+# Manual test (requires admin JWT):
+curl -X GET http://localhost:8080/api/waitlist/stats \
+  -H "Authorization: Bearer <admin-jwt-token>"
+```
+
+### Notes
+
+- Uses same middleware pattern as UserRouter for admin protection
+- `UserAccountModel.guard()` ensures user is authenticated
+- `EnsureAdminUserMiddleware()` ensures user has admin privileges
+- Notification is sequential to respect Brevo rate limits
+- Failed notifications are logged but don't stop the process
+- Consider adding batch delay for large lists (future enhancement)

--- a/docs/planning/work/waitlist-email/TASK-010-repository-integration.md
+++ b/docs/planning/work/waitlist-email/TASK-010-repository-integration.md
@@ -1,0 +1,76 @@
+## TASK-010: Integrate WaitlistRepository with ServiceCache
+
+---
+**Status:** OPEN
+**Branch:** feature/waitlist-email
+**Type:** INTEGRATION
+**Phase:** 1
+**Depends On:** TASK-002
+---
+
+### Overview
+
+Wire up the WaitlistRepository to the ServiceCache so it can be accessed via `application.serviceCache.waitlistRepository` and `request.services.waitlist`. This follows the existing pattern used by UserRepository.
+
+**Files:**
+- `Sources/App/Common/ServiceRegistry/ServiceCache.swift` (modify - if exists)
+- `Sources/App/Modules/Waitlist/Repositories/WaitlistRepository.swift` (modify - add extensions)
+
+### Implementation Steps
+
+**Commit 1: Add repository integration to ServiceCache**
+- [ ] Add `waitlistRepository` property to ServiceCache (or appropriate service container)
+- [ ] Add `Application.Repositories.waitlist` extension
+- [ ] Add `Request.Services.waitlist` extension
+- [ ] Ensure repository is initialized with database connection
+
+### Code Example
+
+```swift
+// Add to WaitlistRepository.swift at the bottom
+// Pattern from UserRepository.swift:126-137
+
+extension Application.Repositories {
+    var waitlist: any WaitlistRepository {
+        guard let repository = application.serviceCache.waitlistRepository as? WaitlistRepository else {
+            return DatabaseWaitlistRepository(database: application.db)
+        }
+        return repository
+    }
+}
+
+extension Request.Services {
+    var waitlist: any WaitlistRepository {
+        DatabaseWaitlistRepository(database: request.db)
+    }
+}
+```
+
+```swift
+// If ServiceCache pattern is used, add property:
+// Sources/App/Common/ServiceRegistry/ServiceCache.swift
+
+var waitlistRepository: any WaitlistRepository {
+    DatabaseWaitlistRepository(database: application.db)
+}
+```
+
+### Success Criteria
+
+- [ ] Build succeeds
+- [ ] `application.serviceCache.waitlistRepository` accessible
+- [ ] `request.services.waitlist` accessible
+- [ ] Repository uses correct database connection
+
+### Verification
+
+```bash
+swift build
+```
+
+### Notes
+
+- Check existing ServiceCache implementation for exact pattern
+- May need to use `application.db` or `request.db` depending on pattern
+- This integration allows controller to access repository easily
+- Follow exact pattern from UserRepository for consistency

--- a/docs/planning/work/waitlist-email/plan.md
+++ b/docs/planning/work/waitlist-email/plan.md
@@ -1,0 +1,267 @@
+# Implementation Plan: Waitlist Email Collection & Notification System
+
+---
+**Date:** 2025-12-03
+**Requirements:** `docs/planning/work/waitlist-email/requirements.md`
+**Research:** `docs/planning/work/waitlist-email/research.md`
+**Branch:** `feature/waitlist-email`
+**Status:** draft
+---
+
+## Summary
+
+**What:** Create a waitlist management system to collect emails from a landing page, send confirmation emails via Brevo, and enable bulk launch notifications.
+**Why:** Enable pre-launch user acquisition and direct communication channel with interested users.
+**Who:** Landing page visitors (public), admin users (notifications).
+
+## Technical Context
+
+**Stack:** Swift 5.9+ / Vapor 4.110+
+**Version:** macOS/Linux server deployment
+**Build:** Swift Package Manager (SPM)
+
+**Key Dependencies:**
+- Fluent: Database ORM for waitlist model
+- Brevo API: Email delivery (existing)
+- VaporToOpenAPI: API documentation
+
+**Architecture:** Modular with Repository Pattern
+- Rationale: Consistent with existing User, Auth, Rules modules
+
+**Files:**
+| File | Action | Purpose |
+|------|--------|---------|
+| `Sources/App/Modules/Waitlist/WaitlistModule.swift` | create | Module registration |
+| `Sources/App/Modules/Waitlist/WaitlistRouter.swift` | create | Route definitions |
+| `Sources/App/Modules/Waitlist/WaitlistController.swift` | create | Business logic |
+| `Sources/App/Modules/Waitlist/Repositories/WaitlistRepository.swift` | create | Data access |
+| `Sources/App/Modules/Waitlist/Database/Models/WaitlistEntryModel.swift` | create | Database model |
+| `Sources/App/Modules/Waitlist/Database/Migrations/WaitlistMigrations.swift` | create | Schema migration |
+| `Sources/App/Modules/Waitlist/Models/Waitlist+Model.swift` | create | Request/Response DTOs |
+| `Sources/App/Services/Email/Helpers/Templates.swift` | modify | Add waitlist templates |
+| `Sources/App/Services/Email/Helpers/WaitlistNotifier.swift` | create | Email helper |
+| `Sources/App/Entrypoint/Application-Setup.swift` | modify | Register module |
+| `Sources/App/Middlewares/Security/RateLimit/RateLimitTypes.swift` | modify | Add waitlist type |
+| `Sources/App/Middlewares/Security/RateLimit/RateLimitMiddleware.swift` | modify | Add waitlist path |
+
+## Technical Decisions
+
+1. **Database over file storage:** PostgreSQL via Fluent - Consistency with existing patterns, better querying
+2. **Unhashed unsubscribe tokens:** UUID stored directly - Lower security requirement than auth tokens
+3. **Dedicated rate limit type:** `waitlist` with 10 req/hour - Prevents spam while allowing legitimate use
+4. **Batch notification:** Sequential with configurable batch size - Avoid Brevo rate limits
+
+## Phase Breakdown
+
+### Phase 0: Database Foundation
+**Goal:** Create database model and migration for waitlist entries
+
+**Deliverables:**
+- [ ] `WaitlistEntryModel.swift` with fields: id, email, unsubscribeToken, createdAt, notifiedAt
+- [ ] `WaitlistMigrations.swift` with v1 migration
+- [ ] Unique constraint on email column
+
+**Dependencies:** None
+**Effort:** 1-2 hours
+
+**Success Criteria:**
+- Migration runs successfully
+- Model can be created and queried in tests
+
+**Approach:** Follow `UserAccountModel` pattern exactly. Use FieldKeys struct for versioned field names. Include unique constraint on email to prevent duplicates at database level.
+
+---
+
+### Phase 1: Repository & Module Setup
+**Goal:** Create data access layer and module structure
+
+**Deliverables:**
+- [ ] `WaitlistRepository.swift` protocol and database implementation
+- [ ] `WaitlistModule.swift` conforming to ModuleInterface
+- [ ] Register module in `Application-Setup.swift`
+- [ ] `Waitlist+Model.swift` with DTOs (Subscribe request/response)
+
+**Dependencies:** Phase 0
+**Effort:** 1-2 hours
+
+**Success Criteria:**
+- Module boots without errors
+- Repository methods work (create, findByEmail, findByToken, delete, all)
+
+**Approach:** Follow `UserRepository` pattern. Include methods for: create, findByEmail, findByToken, delete, all, findUnnotified. Register in setupModules() array.
+
+---
+
+### Phase 2: Email Templates & Notifier
+**Goal:** Create email templates and helper for sending waitlist emails
+
+**Deliverables:**
+- [ ] Add `waitlistConfirmation(unsubscribeToken:baseURL:)` to `Templates.swift`
+- [ ] Add `waitlistLaunchNotification(unsubscribeToken:baseURL:)` to `Templates.swift`
+- [ ] Create `WaitlistNotifier.swift` helper (similar to EmailVerifier)
+
+**Dependencies:** Phase 1
+**Effort:** 1-2 hours
+
+**Success Criteria:**
+- Templates render valid HTML with unsubscribe links
+- WaitlistNotifier can send both email types
+
+**Approach:** Copy existing `verifyEmail` template structure. Include unsubscribe link in footer. Keep content simple/placeholder per user request. WaitlistNotifier follows EmailVerifier pattern.
+
+---
+
+### Phase 3: Rate Limiting
+**Goal:** Add waitlist-specific rate limiting to prevent abuse
+
+**Deliverables:**
+- [ ] Add `waitlist` case to `RateLimitType` enum
+- [ ] Add `waitlistLimit` and `waitlistWindow` to `RateLimitConfiguration`
+- [ ] Add path detection for `/api/waitlist` in `RateLimitMiddleware`
+
+**Dependencies:** None (can be parallel with Phase 1-2)
+**Effort:** 30 minutes
+
+**Success Criteria:**
+- Requests to `/api/waitlist` use waitlist-specific limits
+- 429 returned when limit exceeded
+
+**Approach:** Add new case to RateLimitType. Configure moderate limits (10 requests/hour). Add path check in determineRateLimit() before general API catch-all.
+
+---
+
+### Phase 4: Public Endpoints (Subscribe & Unsubscribe)
+**Goal:** Implement public-facing API endpoints
+
+**Deliverables:**
+- [ ] `WaitlistRouter.swift` with route definitions
+- [ ] `WaitlistController.swift` with subscribe() and unsubscribe() methods
+- [ ] `POST /api/waitlist` - Add email to waitlist
+- [ ] `GET /api/waitlist/unsubscribe/:token` - Remove from waitlist
+- [ ] OpenAPI documentation for both endpoints
+
+**Dependencies:** Phase 1, Phase 2, Phase 3
+**Effort:** 2-3 hours
+
+**Success Criteria:**
+- Subscribe returns 200 and sends confirmation email
+- Duplicate email returns 200 (idempotent) without duplicate entry
+- Invalid email returns 400
+- Valid unsubscribe token removes entry, returns 200
+- Invalid token returns 404
+
+**Approach:** Controller validates email format, checks for existing entry (return success if exists), creates new entry with UUID token, sends confirmation email async. Unsubscribe looks up by token, deletes if found.
+
+---
+
+### Phase 5: Admin Notification Endpoint
+**Goal:** Implement admin-only bulk notification capability within WaitlistModule
+
+**Deliverables:**
+- [ ] `POST /api/waitlist/notify` - Send launch notification to all (admin only)
+- [ ] `GET /api/waitlist/stats` - Get waitlist statistics (admin only)
+- [ ] Batch processing for bulk email sending
+- [ ] Update notifiedAt timestamp after sending
+
+**Dependencies:** Phase 4
+**Effort:** 2-3 hours
+
+**Success Criteria:**
+- Only admins can access endpoints (401 for non-admin)
+- Notification sends to all un-notified entries
+- Each entry's notifiedAt is updated after successful send
+- Stats endpoint returns total count, notified count, pending count
+
+**Approach:** Add admin-protected routes in WaitlistRouter using `EnsureAdminUserMiddleware()` (same pattern as UserRouter.swift:48-55). Keep all endpoints under `/api/waitlist` path. Query findUnnotified(), iterate in batches, send email, update notifiedAt. Handle failures gracefully (log, continue).
+
+---
+
+### Phase 6: Testing & Documentation
+**Goal:** Ensure quality and document the feature
+
+**Deliverables:**
+- [ ] Unit tests for WaitlistRepository
+- [ ] Integration tests for endpoints
+- [ ] OpenAPI documentation complete
+- [ ] Update API documentation if needed
+
+**Dependencies:** Phase 5
+**Effort:** 2-3 hours
+
+**Success Criteria:**
+- All tests pass
+- OpenAPI spec includes all waitlist endpoints
+- Manual testing confirms email delivery
+
+**Approach:** Follow existing test patterns in `Tests/AppTests/`. Create `WaitlistTests.swift`. Test happy paths and edge cases (duplicate, invalid email, rate limit).
+
+---
+
+## Implementation Strategy
+
+**State Management:** Database via Fluent ORM
+- Waitlist entries stored in PostgreSQL
+- notifiedAt tracks notification status
+
+**Data Flow:**
+1. User submits email → Rate limit check → Validate → Store → Send confirmation
+2. User clicks unsubscribe → Lookup token → Delete entry → Confirm
+3. Admin triggers notify → Query un-notified → Batch send → Update timestamps
+
+**Error Handling:** Vapor Abort pattern
+- 400: Invalid email format
+- 404: Unsubscribe token not found
+- 429: Rate limit exceeded
+- 500: Email service failure (logged, but don't fail request)
+
+**Performance:**
+- Unique index on email for fast duplicate check
+- Index on unsubscribeToken for fast lookup
+- Batch processing for bulk notifications (50 per batch)
+
+## Dependencies & Risks
+
+**Internal:**
+- Phase 1 depends on Phase 0 (model must exist)
+- Phase 4 depends on Phases 1, 2, 3
+- Phase 5 depends on Phase 4
+
+**External:**
+- Brevo API: Must be operational for email sending
+
+**Risks:**
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Brevo rate limits | Low | Medium | Batch with delays, log failures |
+| Spam abuse | Medium | Low | Rate limiting + email validation |
+| Duplicate handling race condition | Low | Low | Database unique constraint |
+
+**Assumptions:**
+- Brevo service is configured and working
+- Landing page will call the API correctly
+- Simple email content is acceptable initially
+
+## Acceptance Mapping
+
+| Criterion | Phase | Verification |
+|-----------|-------|--------------|
+| Valid email stored, confirmation sent | Phase 4 | Integration test |
+| Invalid email returns 400 | Phase 4 | Unit test |
+| Duplicate handled gracefully | Phase 4 | Integration test |
+| Rate limit returns 429 | Phase 3 | Integration test |
+| Unsubscribe removes entry | Phase 4 | Integration test |
+| Admin can bulk notify | Phase 5 | Manual test |
+| Emails include unsubscribe link | Phase 2 | Template inspection |
+
+## Next Steps
+
+1. Review this plan
+2. Run `/tasks` to generate detailed task breakdown
+3. Begin Phase 0 implementation
+
+**Unknowns:**
+- None remaining - all clarified in research phase
+
+---
+**Status:** draft
+**Total Estimated Effort:** 10-15 hours across 6 phases

--- a/docs/planning/work/waitlist-email/requirements.md
+++ b/docs/planning/work/waitlist-email/requirements.md
@@ -1,0 +1,107 @@
+---
+type: feature
+status: draft
+priority: P2
+created: 2025-12-03
+slug: waitlist-email
+feature_branch: feature/waitlist-email
+exploration_cache: .exploration-cache.json
+---
+
+# Waitlist Email Collection & Notification System
+
+## Overview
+
+**Context**: A landing page has been created for the app where users can express interest by providing their email address. Currently, there's no backend capability to capture and store these emails or communicate with interested users.
+
+**Objective**: Create a waitlist management system that:
+1. Accepts email submissions from the landing page
+2. Stores emails in a persistent database
+3. Sends confirmation emails to users who join the waitlist
+4. Enables bulk notifications when the app launches
+
+**Impact**:
+- Potential users can express interest and receive confirmation
+- Marketing team can track waitlist signups
+- Launch communications can reach all interested users
+
+## User Stories
+
+**US-1**: As a visitor, I want to add my email to a waitlist so that I'm notified when the app launches
+- **Given** I'm on the landing page, **When** I submit my email, **Then** I receive a confirmation email
+
+**US-2**: As an admin, I want to notify all waitlist subscribers so that they know the app has launched
+- **Given** the app is ready to launch, **When** I trigger a notification, **Then** all waitlist emails receive the launch announcement
+
+## Requirements
+
+1. **REQ-001**: System must accept email addresses via a public API endpoint with rate limiting
+   - Rationale: Landing page needs to submit emails without authentication; rate limiting prevents abuse/spam
+
+2. **REQ-002**: System must validate email format before storage
+   - Rationale: Prevent invalid/spam entries from polluting the waitlist
+
+3. **REQ-003**: System must store email addresses persistently with timestamps
+   - Rationale: Track when users signed up for analytics and priority ordering
+
+4. **REQ-004**: System must prevent duplicate email entries
+   - Rationale: Each email should only be on the waitlist once
+
+5. **REQ-005**: System must send a confirmation email upon successful signup
+   - Rationale: Users need acknowledgment that their email was received
+
+6. **REQ-006**: System must provide capability to send bulk notifications to all subscribers
+   - Rationale: Enable launch announcements to reach all interested users
+
+7. **REQ-007**: System must track notification status per subscriber
+   - Rationale: Know who has been notified to avoid duplicate notifications
+
+8. **REQ-008**: All emails must include an unsubscribe link
+   - Rationale: Legal compliance and user control over communications
+
+9. **REQ-009**: System must support unsubscribe functionality via unique token
+   - Rationale: Allow users to remove themselves from the waitlist
+
+## Acceptance Criteria
+
+### Functional
+- [ ] **Given** a valid email, **When** submitted to the waitlist endpoint, **Then** email is stored and confirmation sent
+- [ ] **Given** an invalid email format, **When** submitted, **Then** return validation error (400)
+- [ ] **Given** an already-registered email, **When** submitted again, **Then** return appropriate response without duplicate entry
+- [ ] **Given** a successful signup, **When** processed, **Then** user receives confirmation email within 60 seconds
+- [ ] **Given** admin access, **When** bulk notification triggered, **Then** all un-notified subscribers receive launch email
+- [ ] **Given** a valid unsubscribe token, **When** user clicks unsubscribe link, **Then** email is removed from waitlist
+- [ ] **Given** excessive requests from same IP, **When** rate limit exceeded, **Then** return 429 Too Many Requests
+
+### Edge Cases
+- [ ] Handles empty email submission with validation error
+- [ ] Handles malformed email formats (missing @, invalid domain)
+- [ ] Handles concurrent submissions of same email gracefully
+- [ ] Handles email service failure gracefully (stores email, queues notification)
+
+## Affected Areas
+
+**Components**:
+- `WaitlistModule` - New module for waitlist management
+- `EmailService` - Existing service for sending confirmation/notification emails
+- `EmailTemplates` - Add new templates for waitlist confirmation and launch notification
+
+**Files**:
+- `Sources/App/Modules/Waitlist/` - New module directory (model, router, controller, repository, migrations)
+- `Sources/App/Services/Email/Helpers/Templates.swift` - Add waitlist email templates
+- `Sources/App/configure.swift` - Register new module
+
+## Assumptions
+
+- Database storage is preferred over file-based storage (aligns with existing architecture)
+- Brevo email service is already configured and functional
+- No authentication required for the signup endpoint (public API)
+- Admin-only endpoint for triggering bulk notifications
+- Single confirmation email per signup (no email verification flow required)
+- Launch notification is a one-time bulk send operation
+- Rate limiting applied to signup endpoint (use existing RateLimitMiddleware)
+- Email templates will use simple placeholder content (user to refine later)
+- Unsubscribe via unique token per subscriber
+
+---
+**Next Steps**: Run `/plan` to create detailed implementation planning.

--- a/docs/planning/work/waitlist-email/research.md
+++ b/docs/planning/work/waitlist-email/research.md
@@ -1,0 +1,283 @@
+# Research: Waitlist Email Collection & Notification System
+
+---
+**Date:** 2025-12-03
+**Requirements:** `docs/planning/work/waitlist-email/requirements.md`
+**Exploration Cache:** Loaded from `.exploration-cache.json`
+**Cache Age:** Same day
+**Status:** complete
+---
+
+## Platform Detection
+
+**Stack:** Swift 5.9+ / Vapor 4.110+
+**Version:** macOS/Linux server deployment
+**Build:** Swift Package Manager (SPM)
+
+## Dependencies
+
+| Dependency | Version | Purpose | Status |
+|------------|---------|---------|--------|
+| Vapor | 4.110+ | Web framework | existing |
+| Fluent | 4.x | ORM for database models | existing |
+| FluentPostgresDriver | 4.x | PostgreSQL support | existing |
+| VaporToOpenAPI | 4.x | OpenAPI documentation | existing |
+| Brevo API | v3 | Email sending service | existing |
+
+## Codebase Patterns
+
+### Architecture
+- **Pattern:** Modular Architecture with Repository Pattern
+  - Location: `Sources/App/Modules/User/UserModule.swift:1-16`
+  - Usage: Each feature is a self-contained module with Model, Router, Controller, Repository
+
+### Conventions
+- **State:** Database via Fluent ORM - `Sources/App/Modules/User/Database/Models/UserAccountModel.swift`
+- **Errors:** Vapor Abort errors - `Sources/App/Middlewares/EnsureAdminUserMiddleware.swift:8`
+- **Async:** async/await throughout - `Sources/App/Modules/User/Controllers/UserController.swift`
+- **Naming:** Files: PascalCase, Types: PascalCase, Funcs: camelCase
+
+### Code Examples
+
+**Module Structure Pattern:**
+```swift
+// Sources/App/Modules/User/UserModule.swift:1-16
+struct UserModule: ModuleInterface {
+    let router = UserRouter()
+
+    func boot(_ app: Application) throws {
+        app.migrations.add(UserMigrations.v1())
+        if app.environment == .development {
+            app.migrations.add(UserMigrations.seed())
+        }
+        try router.boot(routes: app.routes)
+    }
+}
+```
+
+**Fluent Model Pattern:**
+```swift
+// Sources/App/Modules/User/Database/Models/UserAccountModel.swift:1-66
+final class UserAccountModel: @unchecked Sendable, DatabaseModelInterface, Authenticatable {
+    typealias Module = UserModule
+    static var schema: String { "users" }
+
+    @ID() var id: UUID?
+    @Field(key: FieldKeys.v1.email) var email: String
+    @Timestamp(key: FieldKeys.v1.createdAt, on: .create) var createdAt: Date?
+    // ... field keys pattern for versioned migrations
+}
+
+extension UserAccountModel {
+    struct FieldKeys {
+        struct v1 {
+            static var email: FieldKey { "email" }
+            // ...
+        }
+    }
+}
+```
+
+**Migration Pattern:**
+```swift
+// Sources/App/Modules/User/Database/Migrations/UserMigrations.swift:4-29
+enum UserMigrations {
+    struct v1: AsyncMigration {
+        func prepare(on db: Database) async throws {
+            try await db.schema(UserAccountModel.schema)
+                .id()
+                .field(UserAccountModel.FieldKeys.v1.email, .string, .required)
+                .unique(on: UserAccountModel.FieldKeys.v1.email)
+                .create()
+        }
+        func revert(on db: Database) async throws {
+            try await db.schema(UserAccountModel.schema).delete()
+        }
+    }
+}
+```
+
+**Router Pattern with OpenAPI:**
+```swift
+// Sources/App/Modules/User/UserRouter.swift:1-57
+struct UserRouter: RouteCollection {
+    let userController = UserController()
+
+    func boot(routes: RoutesBuilder) throws {
+        user(routes: routes)
+    }
+}
+
+private extension UserRouter {
+    func user(routes: RoutesBuilder) {
+        let api = routes
+            .grouped("api")
+            .grouped("user")
+            .groupedOpenAPI(tags: .init(name: "User", description: "..."))
+
+        // Public endpoints or protected endpoints with middleware
+        let protectedAPI = api.grouped(UserAccountModel.guard())
+
+        protectedAPI
+            .grouped(EnsureAdminUserMiddleware())
+            .get("list", use: userController.list)
+            .openAPI(description: "...", response: .type([User.Detail.Response].self))
+    }
+}
+```
+
+**Repository Pattern:**
+```swift
+// Sources/App/Modules/User/Repositories/UserRepository.swift:1-50
+protocol UserRepository: Repository {
+    func find(id: UUID) async throws -> UserAccountModel?
+    func find(email: String) async throws -> UserAccountModel?
+    func create(_ model: UserAccountModel) async throws
+    func all() async throws -> [UserAccountModel]
+}
+
+struct DatabaseUserRepository: UserRepository, DatabaseRepository {
+    typealias Model = UserAccountModel
+    let database: Database
+
+    func find(email: String) async throws -> UserAccountModel? {
+        try await UserAccountModel.query(on: database)
+            .filter(\.$email == email)
+            .first()
+    }
+}
+```
+
+**Email Sending Pattern:**
+```swift
+// Sources/App/Services/Email/Helpers/EmailVerifier.swift:1-35
+struct EmailVerifier {
+    let emailTokenRepository: any EmailTokenRepository
+    let generator: RandomGeneratorService
+    let application: Application
+
+    func verify(for user: UserAccountModel) async throws {
+        let token = generator.generate(bits: 256)
+        let content = BrevoMail(
+            sender: .init(name: "Sender", email: "noreply@sender.com"),
+            to: [.init(name: name, email: user.email)],
+            subject: "Verify your account",
+            htmlContent: Templates.verifyEmail(token: emailToken.value, baseURL: ...)
+        )
+        try await application.serviceCache.emailService.send(content)
+    }
+}
+```
+
+**Email Template Pattern:**
+```swift
+// Sources/App/Services/Email/Helpers/Templates.swift:1-324
+enum Templates {
+    static func verifyEmail(token: String, baseURL: String) -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8">
+            <!-- ... full HTML email template ... -->
+        </head>
+        <body>
+            <a href="\(baseURL)/verify-email?token=\(token)">Verify email</a>
+        </body>
+        </html>
+        """
+    }
+}
+```
+
+**Rate Limiting Pattern:**
+```swift
+// Sources/App/Middlewares/Security/RateLimit/RateLimitMiddleware.swift:167-211
+private func determineRateLimit(for request: Request) -> RateLimitInfo {
+    let path = request.url.path
+
+    if path.contains("/api/rules-generation/game-box-analysis") {
+        return RateLimitInfo(type: .imageAnalysis, maxRequests: ..., windowSeconds: ...)
+    }
+    if path.hasPrefix("/api/") {
+        return RateLimitInfo(type: .api, maxRequests: ..., windowSeconds: ...)
+    }
+    return RateLimitInfo(type: .general, maxRequests: ..., windowSeconds: ...)
+}
+```
+
+## Integration Points
+
+| Component | Location | Change | Impact |
+|-----------|----------|--------|--------|
+| WaitlistModule | `Sources/App/Modules/Waitlist/` | create | New module |
+| WaitlistModel | `Sources/App/Modules/Waitlist/Database/Models/` | create | New table |
+| WaitlistMigrations | `Sources/App/Modules/Waitlist/Database/Migrations/` | create | Schema |
+| WaitlistRepository | `Sources/App/Modules/Waitlist/Repositories/` | create | Data access |
+| WaitlistRouter | `Sources/App/Modules/Waitlist/` | create | Endpoints |
+| WaitlistController | `Sources/App/Modules/Waitlist/` | create | Business logic |
+| Templates | `Sources/App/Services/Email/Helpers/Templates.swift` | modify | Add templates |
+| Application-Setup | `Sources/App/Entrypoint/Application-Setup.swift:83-89` | modify | Register module |
+| RateLimitTypes | `Sources/App/Middlewares/Security/RateLimit/RateLimitTypes.swift` | modify | Add waitlist type |
+| RateLimitMiddleware | `Sources/App/Middlewares/Security/RateLimit/RateLimitMiddleware.swift` | modify | Add waitlist path |
+
+**Flow:**
+1. `POST /api/waitlist` → `RateLimitMiddleware` → `WaitlistRouter` → `WaitlistController.subscribe`
+2. `WaitlistController` → `WaitlistRepository.findByEmail` (check duplicate)
+3. `WaitlistRepository.create` → Database
+4. `EmailService.send` → Brevo API → Confirmation email
+5. `GET /api/waitlist/unsubscribe/:token` → `WaitlistController.unsubscribe` → Delete from DB
+6. `POST /api/waitlist/notify` → `EnsureAdminUserMiddleware` → Bulk email send (admin only, same module)
+
+## Clarifications & Decisions
+
+### Rate Limiting for Waitlist
+**Question:** How should rate limiting work for the waitlist endpoint?
+**Finding:** Existing rate limit system uses path-based detection in `RateLimitMiddleware`
+**Decision:** Add new `waitlist` rate limit type with moderate limits (e.g., 10 requests/hour per IP)
+**Rationale:** Prevents spam while allowing legitimate signups; stricter than general API but not as strict as AI endpoints
+
+### Database vs File Storage
+**Question:** Where to store waitlist emails?
+**Finding:** All other data uses Fluent/PostgreSQL; existing migration patterns well established
+**Decision:** Use PostgreSQL via Fluent with dedicated `waitlist` table
+**Rationale:** Consistency with existing patterns, better querying for bulk operations, transactional safety
+
+### Unsubscribe Token Strategy
+**Question:** How to implement secure unsubscribe?
+**Finding:** Auth module uses SHA256-hashed tokens stored in DB (`EmailTokenModel` pattern)
+**Decision:** Store unhashed unique token per waitlist entry, include in email URL
+**Rationale:** Waitlist tokens don't need same security level as auth tokens; simpler implementation
+
+## Risks & Unknowns
+
+**Risks:**
+1. **Email delivery failures** - Mitigation: Store email first, send async; log failures for retry
+2. **Bulk notification performance** - Mitigation: Batch emails, use background job pattern
+3. **Rate limit bypass via IP rotation** - Mitigation: Also validate email format, consider honeypot
+
+**Unknowns:**
+- [x] Rate limiting approach - Decided: Add waitlist-specific rate limit
+- [x] Storage choice - Decided: PostgreSQL via Fluent
+- [x] Unsubscribe mechanism - Decided: Token-based URL
+
+## Summary
+
+**Key Findings:**
+1. Codebase has well-established module pattern (User, Auth, Rules modules) to follow exactly
+2. Email service (Brevo) is fully operational with template system in place
+3. Rate limiting middleware supports path-based operation types, easy to extend
+4. Admin middleware (`EnsureAdminUserMiddleware`) provides simple admin-only protection
+
+**Confidence:** High
+- Clear patterns to follow
+- All dependencies already in place
+- No external service integration needed (Brevo already configured)
+
+**Next Steps:**
+1. Create plan.md with phased implementation
+2. Generate tasks for each phase
+3. Begin implementation starting with database model
+
+---
+**Ready for Planning:** Yes

--- a/docs/planning/work/waitlist-email/tasks.md
+++ b/docs/planning/work/waitlist-email/tasks.md
@@ -166,7 +166,7 @@ Create a waitlist management system to collect emails from a landing page, send 
 - [x] Build succeeds: `swift build`
 - [x] No warnings
 - [x] Migration runs on app start
-- [ ] Create PR: `feature/waitlist-email` → `staging`
+- [x] Create PR: `feature/waitlist-email` → `staging` (#23)
 
 ---
 
@@ -221,7 +221,7 @@ Create a waitlist management system to collect emails from a landing page, send 
 - [ ] Manual test: subscribe works
 - [ ] Manual test: unsubscribe works
 - [ ] Manual test: admin stats works
-- [ ] Create/Update PR: `feature/waitlist-email` → `staging`
+- [x] Create/Update PR: `feature/waitlist-email` → `staging` (#23)
 
 ---
 

--- a/docs/planning/work/waitlist-email/tasks.md
+++ b/docs/planning/work/waitlist-email/tasks.md
@@ -1,0 +1,288 @@
+# Execution Tasks: Waitlist Email Collection & Notification System
+
+**Branch:** `feature/waitlist-email` → `staging` → `main`
+**Complexity:** Medium
+**Duration:** 8-12 hours
+**Created:** 2025-12-03
+
+---
+
+## Overview
+
+Create a waitlist management system to collect emails from a landing page, send confirmation emails via Brevo, and enable bulk launch notifications.
+
+**Deliverables:**
+- Public endpoint to subscribe to waitlist (`POST /api/waitlist`)
+- Public endpoint to unsubscribe (`GET /api/waitlist/unsubscribe/:token`)
+- Admin endpoint for statistics (`GET /api/waitlist/stats`)
+- Admin endpoint for bulk notifications (`POST /api/waitlist/notify`)
+- Email templates for confirmation and launch notification
+- Rate limiting on public endpoints
+
+---
+
+## Quick Reference
+
+- **Phases:** 2 | **Tasks:** 10 | **Commits:** ~10
+- **Parallel:** T001+T005+T007, T004+T005 | **Critical Path:** T001 → T002 → T003 → T008 → T009
+
+---
+
+## Phase 1: Foundation & Core Infrastructure
+
+**Goal:** Set up database model, repository, module, email templates, and rate limiting
+**PR:** `feat(waitlist): add waitlist module foundation`
+**Deliverable:** All infrastructure ready for endpoint implementation
+
+---
+
+### Task T001: Database Model & Migration
+**Source:** `TASK-001-database-model.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Modules/Waitlist/Database/Models/WaitlistEntryModel.swift`, `Sources/App/Modules/Waitlist/Database/Migrations/WaitlistMigrations.swift`
+[P] **Parallelizable with T005, T007**
+
+**Implementation Steps:**
+- [x] Create directory structure for Waitlist module
+- [x] Create WaitlistEntryModel with fields (id, email, unsubscribeToken, createdAt, notifiedAt)
+- [x] Add FieldKeys struct for versioned field names
+- [x] Create WaitlistMigrations with v1 migration and unique constraints
+
+**Checkpoint:** ✓ Build | ✓ Files compile
+
+---
+
+### Task T002: Repository Implementation
+**Source:** `TASK-002-repository.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Modules/Waitlist/Repositories/WaitlistRepository.swift`
+**Depends on:** T001
+
+**Implementation Steps:**
+- [x] Define WaitlistRepository protocol with all methods
+- [x] Create DatabaseWaitlistRepository implementation
+- [x] Implement: create, findByEmail, findByToken, delete, all, findUnnotified, update, count, countNotified
+
+**Checkpoint:** ✓ Build | ✓ Protocol and impl compile
+
+---
+
+### Task T003: Module Setup & Registration
+**Source:** `TASK-003-module-setup.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Modules/Waitlist/WaitlistModule.swift`, `Sources/App/Entrypoint/Application-Setup.swift`
+**Depends on:** T001, T002
+
+**Implementation Steps:**
+- [x] Create WaitlistModule conforming to ModuleInterface
+- [x] Create placeholder WaitlistRouter
+- [x] Register module in Application-Setup.swift setupModules()
+- [x] Add migration registration in boot()
+
+**Checkpoint:** ✓ Build | ✓ App starts | ✓ Migration runs
+
+---
+
+### Task T004: Request/Response DTOs
+**Source:** `TASK-004-dto-models.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Modules/Waitlist/Models/Waitlist+Model.swift`
+[P] **Parallelizable with T005**
+**Depends on:** T001
+
+**Implementation Steps:**
+- [x] Create Waitlist namespace enum
+- [x] Create Subscribe.Request with email validation
+- [x] Create Subscribe.Response, Unsubscribe.Response
+- [x] Create Stats.Response, Notify.Response
+
+**Checkpoint:** ✓ Build | ✓ DTOs conform to Content
+
+---
+
+### Task T005: Email Templates
+**Source:** `TASK-005-email-templates.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Services/Email/Helpers/Templates.swift`
+[P] **Parallelizable with T001, T004, T007**
+
+**Implementation Steps:**
+- [x] Add waitlistConfirmation() static method
+- [x] Add waitlistLaunchNotification() static method
+- [x] Include unsubscribe link in footer of both
+- [x] Use existing HTML structure pattern
+
+**Checkpoint:** ✓ Build | ✓ Templates compile
+
+---
+
+### Task T006: WaitlistNotifier Helper
+**Source:** `TASK-006-waitlist-notifier.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Services/Email/Helpers/WaitlistNotifier.swift`
+**Depends on:** T005
+
+**Implementation Steps:**
+- [x] Create WaitlistNotifier struct
+- [x] Add sendConfirmation(to:) method
+- [x] Add sendLaunchNotification(to:) method
+- [x] Add Application and Request extensions
+
+**Checkpoint:** ✓ Build | ✓ Uses EmailService correctly
+
+---
+
+### Task T007: Rate Limiting Configuration
+**Source:** `TASK-007-rate-limiting.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Middlewares/Security/RateLimit/RateLimitTypes.swift`, `Sources/App/Middlewares/Security/RateLimit/RateLimitMiddleware.swift`
+[P] **Parallelizable with T001, T005**
+
+**Implementation Steps:**
+- [x] Add `waitlist` case to RateLimitType enum
+- [x] Add path detection for `/api/waitlist` before `/api/` catch-all
+- [x] Configure 10 requests/hour limit
+
+**Checkpoint:** ✓ Build | ✓ No warnings
+
+---
+
+### Task T010: Repository Integration
+**Source:** `TASK-010-repository-integration.md`
+**Type:** INTEGRATION
+**Files:** `Sources/App/Modules/Waitlist/Repositories/WaitlistRepository.swift`
+**Depends on:** T002
+
+**Implementation Steps:**
+- [x] Add Request.Services.waitlist extension
+- [x] Repository accessible via request.services.waitlist
+
+**Checkpoint:** ✓ Build | ✓ Repository accessible via extensions
+
+---
+
+**Phase 1 Completion:**
+- [x] All tasks T001-T007, T010 complete
+- [x] Build succeeds: `swift build`
+- [x] No warnings
+- [x] Migration runs on app start
+- [ ] Create PR: `feature/waitlist-email` → `staging`
+
+---
+
+## Phase 2: API Endpoints
+
+**Goal:** Implement public and admin API endpoints
+**PR:** Continue on `feature/waitlist-email` branch (or separate PR if preferred)
+**Deliverable:** Fully functional waitlist API
+
+---
+
+### Task T008: Public Endpoints (Subscribe & Unsubscribe)
+**Source:** `TASK-008-public-endpoints.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Modules/Waitlist/WaitlistRouter.swift`, `Sources/App/Modules/Waitlist/WaitlistController.swift`
+**Depends on:** T003, T004, T006, T007, T010
+
+**Implementation Steps:**
+- [x] Create WaitlistController with subscribe() method
+- [x] Add unsubscribe() method to controller
+- [x] Update WaitlistRouter with POST /api/waitlist route
+- [x] Add GET /api/waitlist/unsubscribe/:token route
+- [x] Add OpenAPI documentation
+- [x] Handle duplicate emails gracefully (idempotent)
+
+**Checkpoint:** ✓ Build | ✓ Endpoints respond | ✓ Email sent on subscribe
+
+---
+
+### Task T009: Admin Endpoints (Stats & Notify)
+**Source:** `TASK-009-admin-endpoints.md`
+**Type:** IMPLEMENTATION
+**Files:** `Sources/App/Modules/Waitlist/WaitlistRouter.swift`, `Sources/App/Modules/Waitlist/WaitlistController.swift`
+**Depends on:** T008
+
+**Implementation Steps:**
+- [x] Add stats() method to controller
+- [x] Add notify() method with batch processing
+- [x] Add admin route group with EnsureAdminUserMiddleware
+- [x] Add GET /api/waitlist/stats route
+- [x] Add POST /api/waitlist/notify route
+- [x] Update notifiedAt after successful send
+- [x] Add OpenAPI documentation with auth
+
+**Checkpoint:** ✓ Build | ✓ Admin routes protected | ✓ Stats return correct counts
+
+---
+
+**Phase 2 Completion:**
+- [x] All tasks T008-T009 complete
+- [x] Build succeeds: `swift build`
+- [ ] Manual test: subscribe works
+- [ ] Manual test: unsubscribe works
+- [ ] Manual test: admin stats works
+- [ ] Create/Update PR: `feature/waitlist-email` → `staging`
+
+---
+
+## Execution
+
+**Commit Format:**
+```
+feat(waitlist): <description>
+
+- Change 1
+- Change 2
+
+Task: T00X | Phase: N
+```
+
+**Build:** `swift build`
+**Test:** `swift test`
+**Run:** `swift run App serve`
+
+---
+
+## Task Reference
+
+| ID | Phase | Type | Files | Depends On | Status |
+|----|-------|------|-------|------------|--------|
+| T001 | 1 | IMPL | WaitlistEntryModel, Migrations | - | OPEN |
+| T002 | 1 | IMPL | WaitlistRepository | T001 | OPEN |
+| T003 | 1 | IMPL | WaitlistModule, Application-Setup | T001, T002 | OPEN |
+| T004 | 1 | IMPL | Waitlist+Model | T001 | OPEN |
+| T005 | 1 | IMPL | Templates.swift | - | OPEN |
+| T006 | 1 | IMPL | WaitlistNotifier | T005 | OPEN |
+| T007 | 1 | IMPL | RateLimitTypes, RateLimitMiddleware | - | OPEN |
+| T008 | 2 | IMPL | WaitlistRouter, WaitlistController | T003, T004, T006, T007, T010 | OPEN |
+| T009 | 2 | IMPL | WaitlistRouter, WaitlistController | T008 | OPEN |
+| T010 | 1 | INTEG | WaitlistRepository | T002 | OPEN |
+
+---
+
+## Parallel Execution Guide
+
+**Maximum parallelism in Phase 1:**
+- Start together: T001, T005, T007 (no dependencies)
+- After T001: T002, T004
+- After T002: T010
+- After T005: T006
+- After T002 + T010: T003
+
+**Optimal execution order:**
+1. T001 + T005 + T007 (parallel)
+2. T002 + T004 (parallel, after T001)
+3. T006 + T010 (parallel, after T005/T002)
+4. T003 (after T001, T002)
+5. T008 (after T003, T004, T006, T007, T010)
+6. T009 (after T008)
+
+---
+
+## Notes
+
+- Email templates use simple placeholder content - user will refine later
+- Rate limiting set to 10 requests/hour - can be adjusted in configuration
+- Admin endpoints follow UserRouter pattern (same module, middleware-protected)
+- Notification sends sequentially to respect Brevo rate limits
+- Failed email sends are logged but don't block the process


### PR DESCRIPTION
## Summary

- Add complete waitlist management system for collecting emails from landing page
- Implement confirmation emails and bulk launch notifications via Brevo
- Configure rate limiting (10 requests/hour) on public endpoints
- Admin-protected endpoints for statistics and bulk notifications

## Changes

### New Module: Waitlist
- `WaitlistEntryModel` - Database model with email, unsubscribeToken, createdAt, notifiedAt
- `WaitlistRepository` - Data access layer with CRUD and query methods
- `WaitlistModule` - Module registration and migration setup
- `WaitlistController` - Request handlers for all endpoints
- `WaitlistRouter` - Route definitions with OpenAPI documentation

### Email Integration
- `WaitlistNotifier` - Helper for sending confirmation and launch emails
- Email templates for waitlist confirmation and launch notification

### Endpoints
| Endpoint | Method | Auth | Description |
|----------|--------|------|-------------|
| `/api/waitlist` | POST | Public (rate limited) | Subscribe to waitlist |
| `/api/waitlist/unsubscribe/:token` | GET | Public | Unsubscribe from waitlist |
| `/api/waitlist/stats` | GET | Admin | Get waitlist statistics |
| `/api/waitlist/notify` | POST | Admin | Send launch notification to all |

## Test plan

- [ ] Start the app and verify migration runs
- [ ] POST to /api/waitlist with valid email - verify 200 response
- [ ] POST to /api/waitlist with same email - verify idempotent response
- [ ] POST to /api/waitlist with invalid email - verify 400 response
- [ ] GET /api/waitlist/unsubscribe/:token - verify entry deleted
- [ ] GET /api/waitlist/stats (admin) - verify correct counts
- [ ] POST /api/waitlist/notify (admin) - verify emails sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)