### PR TITLE
RULE-151(story 1.2): Implement Remote Config Endpoint

### DIFF
--- a/Sources/App/Common/Extensions/Application+Services.swift
+++ b/Sources/App/Common/Extensions/Application+Services.swift
@@ -29,6 +29,7 @@ final class ServiceStorageContainer: @unchecked Sendable {
     var passwordTokenRepository: (any PasswordTokenRepository)?
     var generatedRuleRepository: (any GeneratedRuleRepository)?
     var waitlistRepository: (any WaitlistRepository)?
+    var configRepository: (any ConfigRepository)?
 
     init() {}
 }
@@ -145,5 +146,10 @@ extension Application {
     var waitlistRepository: any WaitlistRepository {
         get { serviceStorage.waitlistRepository! }
         set { serviceStorage.waitlistRepository = newValue }
+    }
+
+    var configRepository: any ConfigRepository {
+        get { serviceStorage.configRepository! }
+        set { serviceStorage.configRepository = newValue }
     }
 }

--- a/Sources/App/Entrypoint/Application-Setup.swift
+++ b/Sources/App/Entrypoint/Application-Setup.swift
@@ -87,6 +87,7 @@ extension Application {
       RulesGenerationModule(),
       CacheAdminModule(),
       WaitlistModule(),
+      ConfigModule(),
     ]
 
     for module in modules {
@@ -192,6 +193,7 @@ extension Application {
     passwordTokenRepository = DatabasePasswordTokenRepository(database: db)
     generatedRuleRepository = DatabaseGeneratedRuleRepository(database: db)
     waitlistRepository = DatabaseWaitlistRepository(database: db)
+    configRepository = DatabaseConfigRepository(database: db)
 
     // Initialize foundation services (no dependencies)
     randomGeneratorService = RealRandomGeneratorService(app: self)

--- a/Sources/App/Modules/Config/ConfigModule.swift
+++ b/Sources/App/Modules/Config/ConfigModule.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ConfigModule: ModuleInterface {
+
+    let router = ConfigRouter()
+
+    func boot(_ app: Application) throws {
+        app.migrations.add(ConfigMigrations.v1())
+        try router.boot(routes: app.routes)
+    }
+}

--- a/Sources/App/Modules/Config/ConfigRouter.swift
+++ b/Sources/App/Modules/Config/ConfigRouter.swift
@@ -1,0 +1,41 @@
+import Vapor
+import VaporToOpenAPI
+
+struct ConfigRouter: RouteCollection {
+    let controller = ConfigController()
+
+    func boot(routes: RoutesBuilder) throws {
+        let api = routes
+            .grouped("api")
+            .grouped("v1")
+            .grouped("config")
+            .groupedOpenAPI(tags: .init(name: "Config", description: "Remote configuration for mobile apps"))
+
+        // Public endpoint (no authentication required)
+        api
+            .get(use: controller.getConfig)
+            .openAPI(
+                description: "Get remote configuration values including feature flags and settings. Public endpoint, no authentication required.",
+                response: .type(Config.Response.self)
+            )
+
+        // Admin endpoints (requires admin authentication)
+        let adminAPI = routes
+            .grouped("api")
+            .grouped("v1")
+            .grouped("admin")
+            .grouped("config")
+            .groupedOpenAPI(tags: .init(name: "Config Admin", description: "Configuration management for administrators"))
+            .grouped(UserAccountModel.guard())
+            .grouped(EnsureAdminUserMiddleware())
+
+        adminAPI
+            .put(use: controller.updateConfig)
+            .openAPI(
+                description: "Update configuration values. Invalidates cache immediately. Admin only.",
+                body: .type(Config.Update.Request.self),
+                response: .type(Config.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+    }
+}

--- a/Sources/App/Modules/Config/Controller/ConfigController.swift
+++ b/Sources/App/Modules/Config/Controller/ConfigController.swift
@@ -1,0 +1,58 @@
+import Vapor
+
+struct ConfigController {
+
+    private static let cacheKey = "config:all"
+    private static let cacheTTL: TimeInterval = 300 // 5 minutes
+
+    // MARK: - Public Endpoints
+
+    func getConfig(_ req: Request) async throws -> Config.Response {
+        // Try cache first
+        if let cached = try await req.application.cacheService.get(Self.cacheKey, as: Config.Response.self) {
+            return cached
+        }
+
+        // Cache miss - fetch from database
+        let repository = req.repositories.config
+        let values = try await repository.all()
+
+        // Build response from database values
+        let response = Config.Response(from: values)
+
+        // Cache the response
+        try await req.application.cacheService.set(Self.cacheKey, value: response, ttl: Self.cacheTTL)
+
+        return response
+    }
+
+    // MARK: - Admin Endpoints
+
+    func updateConfig(_ req: Request) async throws -> Config.Response {
+        let updateRequest = try req.content.decode(Config.Update.Request.self)
+        let repository = req.repositories.config
+
+        // Update each provided config value
+        for item in updateRequest.items {
+            if let existing = try await repository.find(key: item.key) {
+                existing.value = item.value
+                existing.valueType = item.valueType.rawValue
+                try await repository.update(existing)
+            } else {
+                let newConfig = ConfigValueModel(
+                    key: item.key,
+                    value: item.value,
+                    valueType: item.valueType.rawValue
+                )
+                try await repository.create(newConfig)
+            }
+        }
+
+        // Invalidate cache
+        try await req.application.cacheService.delete(Self.cacheKey)
+
+        // Return updated config
+        let values = try await repository.all()
+        return Config.Response(from: values)
+    }
+}

--- a/Sources/App/Modules/Config/Database/Migrations/ConfigMigrations.swift
+++ b/Sources/App/Modules/Config/Database/Migrations/ConfigMigrations.swift
@@ -1,0 +1,24 @@
+import Fluent
+import Vapor
+
+enum ConfigMigrations {
+
+    struct v1: AsyncMigration {
+
+        func prepare(on db: Database) async throws {
+            try await db.schema(ConfigValueModel.schema)
+                .id()
+                .field(ConfigValueModel.FieldKeys.v1.key, .string, .required)
+                .field(ConfigValueModel.FieldKeys.v1.value, .string, .required)
+                .field(ConfigValueModel.FieldKeys.v1.valueType, .string, .required)
+                .field(ConfigValueModel.FieldKeys.v1.createdAt, .datetime)
+                .field(ConfigValueModel.FieldKeys.v1.updatedAt, .datetime)
+                .unique(on: ConfigValueModel.FieldKeys.v1.key)
+                .create()
+        }
+
+        func revert(on db: Database) async throws {
+            try await db.schema(ConfigValueModel.schema).delete()
+        }
+    }
+}

--- a/Sources/App/Modules/Config/Database/Models/ConfigValueModel.swift
+++ b/Sources/App/Modules/Config/Database/Models/ConfigValueModel.swift
@@ -1,0 +1,59 @@
+import Fluent
+import Vapor
+
+final class ConfigValueModel: @unchecked Sendable, DatabaseModelInterface {
+    typealias Module = ConfigModule
+    static var schema: String { "config_values" }
+
+    @ID()
+    var id: UUID?
+
+    @Field(key: FieldKeys.v1.key)
+    var key: String
+
+    @Field(key: FieldKeys.v1.value)
+    var value: String
+
+    @Field(key: FieldKeys.v1.valueType)
+    var valueType: String
+
+    @Timestamp(key: FieldKeys.v1.createdAt, on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: FieldKeys.v1.updatedAt, on: .update)
+    var updatedAt: Date?
+
+    init() { }
+
+    init(
+        id: UUID? = nil,
+        key: String,
+        value: String,
+        valueType: String
+    ) {
+        self.id = id
+        self.key = key
+        self.value = value
+        self.valueType = valueType
+    }
+
+    /// Decode the stored value based on the value type
+    var decodedValue: AnyCodableValue {
+        guard let type = Config.ValueType(rawValue: valueType) else {
+            return .string(value)
+        }
+        return AnyCodableValue.from(value, type: type)
+    }
+}
+
+extension ConfigValueModel {
+    struct FieldKeys {
+        struct v1 {
+            static var key: FieldKey { "key" }
+            static var value: FieldKey { "value" }
+            static var valueType: FieldKey { "value_type" }
+            static var createdAt: FieldKey { "created_at" }
+            static var updatedAt: FieldKey { "updated_at" }
+        }
+    }
+}

--- a/Sources/App/Modules/Config/Models/Config+Model.swift
+++ b/Sources/App/Modules/Config/Models/Config+Model.swift
@@ -1,0 +1,147 @@
+import Vapor
+
+enum Config {
+
+    // MARK: - Public Response
+
+    struct Response: Content {
+        let featureFlags: [String: Bool]
+        let settings: [String: AnyCodableValue]
+        let version: String
+
+        init(featureFlags: [String: Bool] = [:], settings: [String: AnyCodableValue] = [:], version: String = "1.0.0") {
+            self.featureFlags = featureFlags
+            self.settings = settings
+            self.version = version
+        }
+
+        init(from models: [ConfigValueModel]) {
+            var featureFlags: [String: Bool] = [:]
+            var settings: [String: AnyCodableValue] = [:]
+            var version = "1.0.0"
+
+            for model in models {
+                let key = model.key
+
+                // Handle special keys
+                if key == "version" {
+                    version = model.value
+                    continue
+                }
+
+                // Handle feature flags (keys starting with "featureFlags.")
+                if key.hasPrefix("featureFlags.") {
+                    let flagName = String(key.dropFirst("featureFlags.".count))
+                    featureFlags[flagName] = model.value.lowercased() == "true"
+                    continue
+                }
+
+                // Handle settings (keys starting with "settings.")
+                if key.hasPrefix("settings.") {
+                    let settingName = String(key.dropFirst("settings.".count))
+                    settings[settingName] = model.decodedValue
+                    continue
+                }
+            }
+
+            self.featureFlags = featureFlags
+            self.settings = settings
+            self.version = version
+        }
+    }
+
+    // MARK: - Admin Update
+
+    enum Update {
+        struct Request: Content {
+            let items: [ConfigItem]
+        }
+
+        struct ConfigItem: Content {
+            let key: String
+            let value: String
+            let valueType: ValueType
+        }
+    }
+
+    // MARK: - Value Types
+
+    enum ValueType: String, Content {
+        case boolean
+        case integer
+        case string
+        case json
+    }
+}
+
+// MARK: - AnyCodableValue
+
+/// A type-erasing wrapper for JSON-compatible values
+enum AnyCodableValue: Codable, Equatable, Sendable {
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([AnyCodableValue])
+    case object([String: AnyCodableValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let double = try? container.decode(Double.self) {
+            self = .double(double)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([AnyCodableValue].self) {
+            self = .array(array)
+        } else if let object = try? container.decode([String: AnyCodableValue].self) {
+            self = .object(object)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unable to decode value")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .bool(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    static func from(_ string: String, type: Config.ValueType) -> AnyCodableValue {
+        switch type {
+        case .boolean:
+            return .bool(string.lowercased() == "true")
+        case .integer:
+            return .int(Int(string) ?? 0)
+        case .string:
+            return .string(string)
+        case .json:
+            guard let data = string.data(using: .utf8),
+                  let value = try? JSONDecoder().decode(AnyCodableValue.self, from: data) else {
+                return .string(string)
+            }
+            return value
+        }
+    }
+}

--- a/Sources/App/Modules/Config/Repositories/ConfigRepository.swift
+++ b/Sources/App/Modules/Config/Repositories/ConfigRepository.swift
@@ -1,0 +1,50 @@
+import Fluent
+import Vapor
+
+protocol ConfigRepository: Repository {
+    func find(id: UUID) async throws -> ConfigValueModel?
+    func find(key: String) async throws -> ConfigValueModel?
+    func create(_ model: ConfigValueModel) async throws
+    func update(_ model: ConfigValueModel) async throws
+    func delete(_ model: ConfigValueModel) async throws
+    func all() async throws -> [ConfigValueModel]
+}
+
+struct DatabaseConfigRepository: ConfigRepository, DatabaseRepository {
+    typealias Model = ConfigValueModel
+    let database: Database
+
+    func find(id: UUID) async throws -> ConfigValueModel? {
+        try await ConfigValueModel.query(on: database)
+            .filter(\.$id == id)
+            .first()
+    }
+
+    func find(key: String) async throws -> ConfigValueModel? {
+        try await ConfigValueModel.query(on: database)
+            .filter(\.$key == key)
+            .first()
+    }
+
+    func create(_ model: ConfigValueModel) async throws {
+        try await model.create(on: database)
+    }
+
+    func update(_ model: ConfigValueModel) async throws {
+        try await model.update(on: database)
+    }
+
+    func delete(_ model: ConfigValueModel) async throws {
+        try await model.delete(on: database)
+    }
+
+    func all() async throws -> [ConfigValueModel] {
+        try await ConfigValueModel.query(on: database).all()
+    }
+}
+
+extension Application.Repositories {
+    var config: any ConfigRepository {
+        application.configRepository
+    }
+}

--- a/Tests/AppTests/Framework/IsolatedTestWorld.swift
+++ b/Tests/AppTests/Framework/IsolatedTestWorld.swift
@@ -81,6 +81,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
     private let emailTokenRepository: TestEmailTokenRepository
     private let passwordTokenRepository: TestPasswordTokenRepository
     private let generatedRuleRepository: TestGeneratedRuleRepository
+    private let configRepository: TestConfigRepository
     
     // MARK: - Mock Services
     private let fakeLLMService: FakeLLMService
@@ -107,6 +108,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
         self.emailTokenRepository = TestEmailTokenRepository()
         self.passwordTokenRepository = TestPasswordTokenRepository()
         self.generatedRuleRepository = TestGeneratedRuleRepository()
+        self.configRepository = TestConfigRepository()
         
         // Create fresh service instances
         self.fakeLLMService = FakeLLMService(app: app)
@@ -148,6 +150,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
         app.emailTokenRepository = self.emailTokenRepository
         app.passwordTokenRepository = self.passwordTokenRepository
         app.generatedRuleRepository = self.generatedRuleRepository
+        app.configRepository = self.configRepository
 
         // Assign mock services directly to Application storage
         app.emailService = FakeEmailProvider()
@@ -217,7 +220,12 @@ final class IsolatedTestWorld: @unchecked Sendable {
     var generatedRules: TestGeneratedRuleRepository {
         generatedRuleRepository
     }
-    
+
+    /// Access to the isolated config repository.
+    var configs: TestConfigRepository {
+        configRepository
+    }
+
     // MARK: - Public Access to Mock Services
     
     /// Access to the isolated LLM service for configuring AI responses.
@@ -254,7 +262,8 @@ final class IsolatedTestWorld: @unchecked Sendable {
         await emailTokenRepository.reset()
         await passwordTokenRepository.reset()
         await generatedRuleRepository.reset()
-        
+        await configRepository.reset()
+
         // Reset services
         fakeLLMService.reset()
         mockAICacheService.reset()

--- a/Tests/AppTests/Framework/Mocks/Repositories/TestConfigRepository.swift
+++ b/Tests/AppTests/Framework/Mocks/Repositories/TestConfigRepository.swift
@@ -1,0 +1,68 @@
+@testable import App
+import Vapor
+import Fluent
+
+actor TestConfigRepository: ConfigRepository, TestRepository {
+    var configs: [ConfigValueModel]
+
+    /// Alias for consistent test interface
+    var entities: [ConfigValueModel] {
+        get { configs }
+        set { configs = newValue }
+    }
+
+    init(configs: [ConfigValueModel] = []) {
+        self.configs = configs
+    }
+
+    typealias Model = ConfigValueModel
+
+    func create(_ model: ConfigValueModel) async throws {
+        // Simulate unique key constraint like a real database
+        if configs.contains(where: { $0.key == model.key }) {
+            throw Abort(.conflict, reason: "UNIQUE constraint failed: config_values.key")
+        }
+        model.id = model.id ?? UUID()
+        configs.append(model)
+    }
+
+    func delete(id: UUID) async throws {
+        configs.removeAll(where: { $0.id == id })
+    }
+
+    func delete(_ model: ConfigValueModel) async throws {
+        configs.removeAll(where: { $0.id == model.id })
+    }
+
+    func find(id: UUID) async throws -> ConfigValueModel? {
+        configs.first(where: { $0.id == id })
+    }
+
+    func find(key: String) async throws -> ConfigValueModel? {
+        configs.first(where: { $0.key == key })
+    }
+
+    func all() async throws -> [ConfigValueModel] {
+        configs
+    }
+
+    func update(_ model: ConfigValueModel) async throws {
+        guard let id = model.id,
+              let index = configs.firstIndex(where: { $0.id == id }) else {
+            throw Abort(.notFound)
+        }
+        configs[index] = model
+    }
+
+    func count() async throws -> Int {
+        configs.count
+    }
+
+    func reset() async {
+        configs.removeAll()
+    }
+
+    nonisolated func `for`(_ req: Request) -> TestConfigRepository {
+        return self
+    }
+}

--- a/Tests/AppTests/Tests/ControllerTests/ConfigTests/ConfigAdminTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/ConfigTests/ConfigAdminTests.swift
@@ -1,0 +1,169 @@
+@testable import App
+import Testing
+import VaporTesting
+
+@Suite(.serialized)
+struct ConfigAdminTests {
+    let testWorld: IsolatedTestWorld
+
+    init() async throws {
+        testWorld = try await IsolatedTestWorld()
+    }
+
+    // MARK: - Authentication Tests
+
+    @Test("PUT /api/v1/admin/config returns 401 without authentication")
+    func testAdminEndpointRequiresAuth() async throws {
+        try await testWorld.app.test(.PUT, "api/v1/admin/config") { req in
+            req.headers.contentType = .json
+            try req.content.encode(Config.Update.Request(items: []))
+        } afterResponse: { response in
+            #expect(response.status == .unauthorized)
+        }
+    }
+
+    @Test("PUT /api/v1/admin/config returns 403 for non-admin user")
+    func testAdminEndpointRequiresAdmin() async throws {
+        // Create a regular (non-admin) user
+        let user = try UserAccountModel.mock(app: testWorld.app)
+        user.isAdmin = false
+        try await testWorld.users.create(user)
+
+        try await testWorld.app.test(.PUT, "api/v1/admin/config", user: user, content: Config.Update.Request(items: []), afterResponse: { response in
+            #expect(response.status == .forbidden)
+        })
+    }
+
+    @Test("PUT /api/v1/admin/config returns 200 for admin user")
+    func testAdminEndpointSucceedsForAdmin() async throws {
+        // Create an admin user
+        let adminUser = try UserAccountModel.mock(app: testWorld.app)
+        adminUser.isAdmin = true
+        try await testWorld.users.create(adminUser)
+
+        try await testWorld.app.test(.PUT, "api/v1/admin/config", user: adminUser, content: Config.Update.Request(items: []), afterResponse: { response in
+            #expect(response.status == .ok)
+        })
+    }
+
+    // MARK: - Update Tests
+
+    @Test("PUT /api/v1/admin/config creates new config values")
+    func testAdminCanCreateConfig() async throws {
+        // Create an admin user
+        let adminUser = try UserAccountModel.mock(app: testWorld.app)
+        adminUser.isAdmin = true
+        try await testWorld.users.create(adminUser)
+
+        let updateRequest = Config.Update.Request(items: [
+            .init(key: "featureFlags.newFeature", value: "true", valueType: .boolean),
+            .init(key: "settings.timeout", value: "30", valueType: .integer)
+        ])
+
+        try await testWorld.app.test(.PUT, "api/v1/admin/config", user: adminUser, content: updateRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.featureFlags["newFeature"] == true)
+            #expect(config.settings["timeout"] == .int(30))
+        })
+    }
+
+    @Test("PUT /api/v1/admin/config updates existing config values")
+    func testAdminCanUpdateExistingConfig() async throws {
+        // Setup: Create existing config
+        let existingConfig = ConfigValueModel(
+            key: "settings.maxRetries",
+            value: "3",
+            valueType: "integer"
+        )
+        try await testWorld.configs.create(existingConfig)
+
+        // Create an admin user
+        let adminUser = try UserAccountModel.mock(app: testWorld.app)
+        adminUser.isAdmin = true
+        try await testWorld.users.create(adminUser)
+
+        let updateRequest = Config.Update.Request(items: [
+            .init(key: "settings.maxRetries", value: "5", valueType: .integer)
+        ])
+
+        try await testWorld.app.test(.PUT, "api/v1/admin/config", user: adminUser, content: updateRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.settings["maxRetries"] == .int(5))
+        })
+    }
+
+    @Test("PUT /api/v1/admin/config supports all value types")
+    func testAdminCanUpdateAllValueTypes() async throws {
+        // Create an admin user
+        let adminUser = try UserAccountModel.mock(app: testWorld.app)
+        adminUser.isAdmin = true
+        try await testWorld.users.create(adminUser)
+
+        let updateRequest = Config.Update.Request(items: [
+            .init(key: "featureFlags.enabled", value: "true", valueType: .boolean),
+            .init(key: "settings.count", value: "42", valueType: .integer),
+            .init(key: "settings.name", value: "test", valueType: .string),
+            .init(key: "settings.data", value: "{\"key\":\"value\"}", valueType: .json)
+        ])
+
+        try await testWorld.app.test(.PUT, "api/v1/admin/config", user: adminUser, content: updateRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.featureFlags["enabled"] == true)
+            #expect(config.settings["count"] == .int(42))
+            #expect(config.settings["name"] == .string("test"))
+
+            if case .object(let obj) = config.settings["data"] {
+                #expect(obj["key"] == .string("value"))
+            } else {
+                Issue.record("Expected JSON object for data")
+            }
+        })
+    }
+
+    // MARK: - Cache Invalidation Tests
+
+    @Test("PUT /api/v1/admin/config invalidates cache")
+    func testAdminUpdateInvalidatesCache() async throws {
+        // Setup: Create initial config and populate cache via GET
+        let initialConfig = ConfigValueModel(
+            key: "settings.value",
+            value: "initial",
+            valueType: "string"
+        )
+        try await testWorld.configs.create(initialConfig)
+
+        // First GET to populate cache
+        try await testWorld.app.test(.GET, "api/v1/config") { response in
+            #expect(response.status == .ok)
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.settings["value"] == .string("initial"))
+        }
+
+        // Create an admin user
+        let adminUser = try UserAccountModel.mock(app: testWorld.app)
+        adminUser.isAdmin = true
+        try await testWorld.users.create(adminUser)
+
+        // Update config
+        let updateRequest = Config.Update.Request(items: [
+            .init(key: "settings.value", value: "updated", valueType: .string)
+        ])
+
+        try await testWorld.app.test(.PUT, "api/v1/admin/config", user: adminUser, content: updateRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+        })
+
+        // GET should return updated value (cache invalidated)
+        try await testWorld.app.test(.GET, "api/v1/config") { response in
+            #expect(response.status == .ok)
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.settings["value"] == .string("updated"))
+        }
+    }
+}

--- a/Tests/AppTests/Tests/ControllerTests/ConfigTests/ConfigGetTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/ConfigTests/ConfigGetTests.swift
@@ -1,0 +1,132 @@
+@testable import App
+import Testing
+import VaporTesting
+
+@Suite(.serialized)
+struct ConfigGetTests {
+    let testWorld: IsolatedTestWorld
+
+    init() async throws {
+        testWorld = try await IsolatedTestWorld()
+    }
+
+    @Test("GET /api/v1/config returns 200 without authentication")
+    func testConfigEndpointPublic() async throws {
+        try await testWorld.app.test(.GET, "api/v1/config") { response in
+            #expect(response.status == .ok)
+        }
+    }
+
+    @Test("GET /api/v1/config returns expected JSON structure")
+    func testConfigResponseStructure() async throws {
+        try await testWorld.app.test(.GET, "api/v1/config") { response in
+            #expect(response.status == .ok)
+
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.version == "1.0.0")
+            #expect(config.featureFlags.isEmpty || !config.featureFlags.isEmpty) // Validates dictionary exists
+            #expect(config.settings.isEmpty || !config.settings.isEmpty) // Validates dictionary exists
+        }
+    }
+
+    @Test("GET /api/v1/config returns feature flags correctly")
+    func testConfigFeatureFlags() async throws {
+        // Setup: Add feature flag config values
+        let enableNewScanner = ConfigValueModel(
+            key: "featureFlags.enableNewScanner",
+            value: "true",
+            valueType: "boolean"
+        )
+        let showPromotion = ConfigValueModel(
+            key: "featureFlags.showPromotion",
+            value: "false",
+            valueType: "boolean"
+        )
+
+        try await testWorld.configs.create(enableNewScanner)
+        try await testWorld.configs.create(showPromotion)
+
+        try await testWorld.app.test(.GET, "api/v1/config") { response in
+            #expect(response.status == .ok)
+
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.featureFlags["enableNewScanner"] == true)
+            #expect(config.featureFlags["showPromotion"] == false)
+        }
+    }
+
+    @Test("GET /api/v1/config returns settings correctly with different types")
+    func testConfigSettingsWithTypes() async throws {
+        // Setup: Add settings with various types
+        let maxRetries = ConfigValueModel(
+            key: "settings.maxRetries",
+            value: "3",
+            valueType: "integer"
+        )
+        let cacheTimeout = ConfigValueModel(
+            key: "settings.cacheTimeoutSeconds",
+            value: "300",
+            valueType: "integer"
+        )
+        let apiUrl = ConfigValueModel(
+            key: "settings.apiUrl",
+            value: "https://api.example.com",
+            valueType: "string"
+        )
+
+        try await testWorld.configs.create(maxRetries)
+        try await testWorld.configs.create(cacheTimeout)
+        try await testWorld.configs.create(apiUrl)
+
+        try await testWorld.app.test(.GET, "api/v1/config") { response in
+            #expect(response.status == .ok)
+
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.settings["maxRetries"] == .int(3))
+            #expect(config.settings["cacheTimeoutSeconds"] == .int(300))
+            #expect(config.settings["apiUrl"] == .string("https://api.example.com"))
+        }
+    }
+
+    @Test("GET /api/v1/config returns custom version when set")
+    func testConfigCustomVersion() async throws {
+        // Setup: Add version config
+        let version = ConfigValueModel(
+            key: "version",
+            value: "2.1.0",
+            valueType: "string"
+        )
+        try await testWorld.configs.create(version)
+
+        try await testWorld.app.test(.GET, "api/v1/config") { response in
+            #expect(response.status == .ok)
+
+            let config = try response.content.decode(Config.Response.self)
+            #expect(config.version == "2.1.0")
+        }
+    }
+
+    @Test("GET /api/v1/config handles JSON value type")
+    func testConfigJsonValueType() async throws {
+        // Setup: Add JSON type setting
+        let jsonConfig = ConfigValueModel(
+            key: "settings.complexConfig",
+            value: "{\"nested\":\"value\",\"number\":42}",
+            valueType: "json"
+        )
+        try await testWorld.configs.create(jsonConfig)
+
+        try await testWorld.app.test(.GET, "api/v1/config") { response in
+            #expect(response.status == .ok)
+
+            let config = try response.content.decode(Config.Response.self)
+            // Verify it's a JSON object
+            if case .object(let obj) = config.settings["complexConfig"] {
+                #expect(obj["nested"] == .string("value"))
+                #expect(obj["number"] == .int(42))
+            } else {
+                Issue.record("Expected JSON object for complexConfig")
+            }
+        }
+    }
+}

--- a/_bmad-output/implementation-artifacts/1-2-implement-remote-config-endpoint.md
+++ b/_bmad-output/implementation-artifacts/1-2-implement-remote-config-endpoint.md
@@ -1,0 +1,472 @@
+# Story 1.2: Implement Remote Config Endpoint
+
+Status: complete
+Linear Issue: RULE-151
+Epic: 1 - API Versioning & Stability
+Created: 2025-12-28
+
+---
+
+## Story
+
+As a mobile app,
+I want to fetch feature flags and configuration from the backend,
+so that app behavior can be controlled remotely without app updates.
+
+## Acceptance Criteria
+
+**Given** a GET request to `/api/v1/config`
+**When** the request is made
+**Then** response returns a JSON dictionary of configuration values:
+```json
+{
+  "featureFlags": {
+    "enableNewScanner": true,
+    "showPromotion": false
+  },
+  "settings": {
+    "maxRetries": 3,
+    "cacheTimeoutSeconds": 300
+  },
+  "version": "1.0.0"
+}
+```
+
+**Given** the config endpoint
+**When** it is called
+**Then** it does NOT require authentication (public endpoint)
+
+**Given** configuration data
+**When** stored in the system
+**Then** it is persisted in PostgreSQL with Redis caching (5 min TTL)
+
+**Given** configuration values
+**When** defining them
+**Then** they support typed values: boolean, integer, string, JSON object
+
+**Given** an admin endpoint `/api/v1/admin/config`
+**When** an authenticated admin updates configuration
+**Then** the cache is invalidated and new values take effect immediately
+
+**Given** a cache miss
+**When** Redis cache expires
+**Then** configuration is re-fetched from PostgreSQL and cached
+
+## Tasks / Subtasks
+
+- [x] Create Config module structure following established patterns (AC: all)
+  - [x] Create `Sources/App/Modules/Config/` directory
+  - [x] Create `ConfigModule.swift` for registration
+  - [x] Create `ConfigRouter.swift` for route definitions
+  - [x] Create `Controller/ConfigController.swift`
+  - [x] Create `Models/Config+Model.swift` for request/response DTOs
+  - [x] Create `Database/Models/ConfigValueModel.swift`
+  - [x] Create `Database/Migrations/ConfigMigrations.swift`
+  - [x] Create `Repositories/ConfigRepository.swift`
+
+- [x] Implement database model for config values (AC: 4)
+  - [x] Define ConfigValueModel with fields: id, key, value (JSON), type, createdAt, updatedAt
+  - [x] Create migration with unique constraint on key
+  - [x] Support types: boolean, integer, string, json
+
+- [x] Implement config repository (AC: 3, 6)
+  - [x] Define ConfigRepository protocol
+  - [x] Implement DatabaseConfigRepository with CRUD operations
+  - [x] Add method to get all config values
+  - [x] Register repository in Application-Setup.swift
+
+- [x] Implement public GET /api/v1/config endpoint (AC: 1, 2)
+  - [x] Return structured response with featureFlags, settings, version
+  - [x] No authentication required (public endpoint)
+  - [x] Transform database values into nested response structure
+
+- [x] Implement Redis caching for config (AC: 3, 6)
+  - [x] Cache entire config response in Redis with 5-minute TTL
+  - [x] Check cache first before database query
+  - [x] Re-cache on miss
+
+- [x] Implement admin PUT /api/v1/admin/config endpoint (AC: 5)
+  - [x] Require admin authentication (EnsureAdminUserMiddleware)
+  - [x] Accept config key-value updates
+  - [x] Invalidate Redis cache on update
+  - [x] Return updated config
+
+- [x] Register module in Application-Setup.swift
+  - [x] Add ConfigModule() to modules array
+  - [x] Register ConfigRepository
+
+- [x] Write comprehensive tests
+  - [x] Test public endpoint returns config without auth
+  - [x] Test config structure matches expected format
+  - [x] Test admin endpoint requires authentication
+  - [x] Test cache invalidation on update
+  - [x] Test typed value handling (boolean, integer, string, JSON)
+
+---
+
+## Relevant Feature Documentation
+
+### API Versioning Strategy
+[Source: docs/features/api-versioning.md]
+
+**Key Patterns to Follow:**
+
+```swift
+// Standard versioned router pattern
+func boot(routes: RoutesBuilder) throws {
+    let api = routes
+        .grouped("api")
+        .grouped("v1")           // REQUIRED: Version prefix
+        .grouped("config")
+        .groupedOpenAPI(tags: .init(name: "Config", description: "Remote configuration"))
+
+    // Define routes under the api group
+    api.get(use: controller.getConfig)
+}
+```
+
+**Testing Pattern:**
+```swift
+@Test("Config endpoint accessible with v1 prefix")
+func testVersionedEndpoint() async throws {
+    try await app.test(.GET, "api/v1/config") { req in
+        // No auth required
+    } afterResponse: { response in
+        #expect(response.status == .ok)
+    }
+}
+```
+
+---
+
+## Developer Context
+
+### Technical Requirements
+
+**Swift 6 Concurrency:**
+- All handlers MUST use `async/await`
+- Mark actors and sendable types correctly
+- Services accessed via `req` are already on correct isolation
+- NO `DispatchQueue` for async work
+
+**Module Boundaries:**
+- Each module owns its Router, Controller, Models, Repository
+- NEVER import one module's internal types into another
+- Cross-module communication through Services only
+- Controllers call Services, Services call Repositories
+
+**Error Handling:**
+- All errors MUST conform to `AppError` enum pattern
+- DO NOT throw raw `Abort(.badRequest)` directly
+
+### Architecture Compliance
+
+**Module Structure (MUST FOLLOW):**
+```
+Modules/Config/
+├── ConfigModule.swift         # Module registration (see WaitlistModule pattern)
+├── ConfigRouter.swift         # Route definitions (see WaitlistRouter pattern)
+├── Controller/
+│   └── ConfigController.swift # HTTP endpoints + business logic
+├── Models/
+│   └── Config+Model.swift     # Request/Response Codable types
+├── Database/
+│   ├── Models/
+│   │   └── ConfigValueModel.swift  # Fluent @Model class
+│   └── Migrations/
+│       └── ConfigMigrations.swift  # Migration definition
+└── Repositories/
+    └── ConfigRepository.swift # Protocol + Database implementation
+```
+
+**Service Access Pattern:**
+```swift
+// In controllers - use req.repositories.*
+func getConfig(_ req: Request) async throws -> Config.Response {
+    let repository = req.repositories.config
+    let values = try await repository.all()
+    return Config.Response(from: values)
+}
+```
+
+**Database Model Pattern (from WaitlistEntryModel):**
+```swift
+final class ConfigValueModel: @unchecked Sendable, DatabaseModelInterface {
+    typealias Module = ConfigModule
+    static var schema: String { "config_values" }
+
+    @ID()
+    var id: UUID?
+
+    @Field(key: FieldKeys.v1.key)
+    var key: String
+
+    @Field(key: FieldKeys.v1.value)
+    var value: String  // JSON encoded
+
+    @Field(key: FieldKeys.v1.valueType)
+    var valueType: String  // boolean, integer, string, json
+
+    @Timestamp(key: FieldKeys.v1.createdAt, on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: FieldKeys.v1.updatedAt, on: .update)
+    var updatedAt: Date?
+}
+```
+
+### Library & Framework Requirements
+
+**Vapor 4.110+ with Swift 6.0:**
+- Use `RoutesBuilder.grouped()` for route prefixes
+- Use `VaporToOpenAPI` for OpenAPI documentation
+- Use Fluent 4.8+ for database operations
+- Use Redis via `RedisCacheService` pattern
+
+**Redis Caching Pattern (from RedisCacheService):**
+```swift
+// Get with TTL
+let cached = try await req.cacheService.get("config:all", as: ConfigResponse.self)
+if let cached = cached { return cached }
+
+// Set with 5-minute TTL
+try await req.cacheService.set("config:all", value: response, ttl: 300)
+```
+
+**Admin Authentication (from CacheAdminRouter):**
+```swift
+let adminAPI = api
+    .grouped(UserAccountModel.guard())
+    .grouped(EnsureAdminUserMiddleware())
+```
+
+### File Structure Requirements
+
+**Files to Create:**
+```
+Sources/App/Modules/Config/
+├── ConfigModule.swift
+├── ConfigRouter.swift
+├── Controller/
+│   └── ConfigController.swift
+├── Models/
+│   └── Config+Model.swift
+├── Database/
+│   ├── Models/
+│   │   └── ConfigValueModel.swift
+│   └── Migrations/
+│       └── ConfigMigrations.swift
+└── Repositories/
+    └── ConfigRepository.swift
+
+Tests/AppTests/Tests/ControllerTests/ConfigTests/
+├── ConfigGetTests.swift
+└── ConfigAdminTests.swift
+```
+
+**Files to Modify:**
+- `Sources/App/Entrypoint/Application-Setup.swift` - Add ConfigModule to modules array, register repository
+
+### Testing Requirements
+
+**IsolatedTestWorld Pattern:**
+```swift
+@Suite(.serialized)
+struct ConfigGetTests {
+    let testWorld: IsolatedTestWorld
+
+    init() async throws {
+        testWorld = try await IsolatedTestWorld()
+    }
+
+    @Test func testConfigEndpoint() async throws {
+        try await testWorld.app.test(.GET, "api/v1/config") { res in
+            #expect(res.status == .ok)
+        }
+    }
+}
+```
+
+**Test Cases Required:**
+1. Public endpoint returns 200 without authentication
+2. Response structure matches expected JSON format
+3. Admin endpoint returns 401 without authentication
+4. Admin endpoint returns 200 with valid admin token
+5. Cache is populated on first request
+6. Cache is invalidated after admin update
+7. Different value types (boolean, integer, string, JSON) serialize correctly
+
+---
+
+## Previous Story Intelligence
+
+### Story 1.1 Learnings
+[Source: _bmad-output/implementation-artifacts/1-1-add-api-version-prefix-to-all-public-routes.md]
+
+**Router Updates Pattern:**
+- All 4 main module routers use `.grouped("v1")` at line 10
+- Pattern: `.grouped("api").grouped("v1").grouped("{module-name}")`
+- VaporToOpenAPI `.groupedOpenAPI()` comes AFTER version prefix
+
+**Test Updates Pattern:**
+- All test paths use `/api/v1/` prefix
+- Negative tests verify old routes return 404
+- Use `app.test(.METHOD, "api/v1/...")` pattern
+
+**Rate Limit Configuration:**
+- If adding new rate limit type, update `RateLimitConfiguration.swift`
+- Update `MockRateLimitService` for testing
+- All configurations (default, production, development) must include new limit type
+
+**Files Changed in Story 1.1:**
+- `Sources/App/Modules/*/Router.swift` - Added `.grouped("v1")`
+- `Sources/App/Middlewares/Security/RateLimit/RateLimitConfiguration.swift`
+- `Tests/AppTests/Framework/Mocks/Services/MockRateLimitService.swift`
+- Various test files updated to use versioned paths
+
+---
+
+## Git Intelligence
+
+### Recent Commits (from main branch)
+- `4a42d69` - Merge PR #26: Story 1.1 - Add v1 prefix to all routes
+
+**Patterns Observed:**
+- API versioning is complete and all routes use `/api/v1/` prefix
+- Rate limiting is configured per-operation type
+- IsolatedTestWorld pattern used for testing
+
+---
+
+## Latest Technical Information
+
+**Vapor 4.x / Swift 6.0:**
+- Strict concurrency checking enabled
+- All async operations must use `async/await`
+- `@unchecked Sendable` needed for database models with property wrappers
+
+**Fluent 4.8+:**
+- Use `@Field`, `@ID`, `@Timestamp` property wrappers
+- Migrations use `AsyncMigration` protocol
+- Database operations are fully async
+
+**Redis Integration:**
+- Use `RedisCacheService` from `Sources/App/Services/Cache/`
+- TTL specified in seconds as `TimeInterval`
+- JSON encoding/decoding handled automatically
+
+---
+
+## Project Context Reference
+
+See: docs/project-context.md
+
+Key patterns and rules from project context:
+
+**Naming Conventions:**
+| Area | Convention | Example |
+|------|------------|---------|
+| Database tables | snake_case, plural | `config_values` |
+| Database columns | snake_case | `created_at`, `value_type` |
+| API endpoints | kebab-case with `/v1/` | `/api/v1/config`, `/api/v1/admin/config` |
+| Swift types | PascalCase | `ConfigController`, `ConfigValueModel` |
+| Swift properties | camelCase | `valueType`, `createdAt` |
+| Protocols | PascalCase | `ConfigRepository` |
+
+**Anti-Patterns (NEVER DO):**
+- `DispatchQueue.global().async` - Use `async/await`
+- `try! force unwrap` - Handle errors properly
+- Raw `Abort()` throws - Use `AppError` enum
+- Hardcoded secrets - Use environment variables
+- Creating new patterns - Follow existing patterns
+
+**Quick Reference - Adding a new module:**
+1. Create directory structure per pattern above
+2. Register in `Application-Setup.swift` modules array
+3. Add routes via module's router
+4. Register repository in setupServices()
+
+---
+
+## Dev Notes
+
+### Implementation Notes
+
+**Response Structure Design:**
+The config endpoint should return a nested structure that mobile apps can easily consume:
+```swift
+struct ConfigResponse: Content {
+    let featureFlags: [String: Bool]
+    let settings: [String: AnyCodable]  // Or use JSON encoding
+    let version: String
+}
+```
+
+Consider using a generic approach for the settings values since they can be boolean, integer, string, or JSON objects.
+
+**Database Design:**
+Store config values as key-value pairs in `config_values` table:
+- `key`: unique string identifier (e.g., "featureFlags.enableNewScanner")
+- `value`: JSON-encoded value
+- `value_type`: enum/string for type validation
+
+**Seeding Initial Config:**
+Consider creating a seed migration that populates default config values, or handle missing keys gracefully in the controller.
+
+### Project Structure Notes
+
+- Alignment with unified project structure: Follows Modules/ pattern exactly
+- No conflicts or variances detected
+
+### References
+
+- [Source: docs/project-context.md#module-structure]
+- [Source: docs/architecture/technical-architecture.md#module-architecture]
+- [Source: docs/features/api-versioning.md]
+- [Source: _bmad-output/epics.md#story-1.2]
+- [Source: _bmad-output/implementation-artifacts/1-1-add-api-version-prefix-to-all-public-routes.md]
+- [Source: Sources/App/Modules/Waitlist/WaitlistModule.swift] - Module registration pattern
+- [Source: Sources/App/Modules/Waitlist/WaitlistRouter.swift] - Router pattern
+- [Source: Sources/App/Modules/Waitlist/WaitlistController.swift] - Controller pattern
+- [Source: Sources/App/Modules/Waitlist/Database/Models/WaitlistEntryModel.swift] - Database model pattern
+- [Source: Sources/App/Modules/Waitlist/Database/Migrations/WaitlistMigrations.swift] - Migration pattern
+- [Source: Sources/App/Modules/Waitlist/Repositories/WaitlistRepository.swift] - Repository pattern
+- [Source: Sources/App/Modules/CacheAdmin/CacheAdminRouter.swift] - Admin authentication pattern
+- [Source: Sources/App/Services/Cache/RedisCacheService.swift] - Redis caching pattern
+- [Source: Sources/App/Entrypoint/Application-Setup.swift:82-99] - Module registration
+
+---
+
+## Dev Agent Record
+
+### Context Reference
+
+Ultimate context engine analysis completed - comprehensive developer guide created.
+
+### Agent Model Used
+
+claude-opus-4-5-20251101
+
+### Debug Log References
+
+### Completion Notes List
+
+- Exhaustive artifact analysis completed for: epics.md, project-context.md, technical-architecture.md, api-versioning.md, previous story 1-1, Application-Setup.swift, all Waitlist module files
+- Previous story intelligence extracted from Story 1.1
+- Git intelligence analyzed from recent commits
+- Module patterns documented from existing Waitlist and CacheAdmin modules
+- All acceptance criteria mapped to tasks
+- Architecture compliance requirements extracted
+
+### File List
+
+Sources/App/Modules/Config/ConfigModule.swift
+Sources/App/Modules/Config/ConfigRouter.swift
+Sources/App/Modules/Config/Controller/ConfigController.swift
+Sources/App/Modules/Config/Models/Config+Model.swift
+Sources/App/Modules/Config/Database/Models/ConfigValueModel.swift
+Sources/App/Modules/Config/Database/Migrations/ConfigMigrations.swift
+Sources/App/Modules/Config/Repositories/ConfigRepository.swift
+Sources/App/Entrypoint/Application-Setup.swift (modify)
+Tests/AppTests/Tests/ControllerTests/ConfigTests/ConfigGetTests.swift
+Tests/AppTests/Tests/ControllerTests/ConfigTests/ConfigAdminTests.swift

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -42,7 +42,7 @@ development_status:
   # Epic 1: API Versioning & Stability
   epic-1: in-progress
   1-1-add-api-version-prefix-to-all-public-routes: done
-  1-2-implement-remote-config-endpoint: backlog
+  1-2-implement-remote-config-endpoint: ready-for-dev
   epic-1-retrospective: optional
 
   # Epic 2: In-App Purchase Verification

--- a/docs/CONDITIONAL_DOCS.md
+++ b/docs/CONDITIONAL_DOCS.md
@@ -19,3 +19,12 @@ This guide helps you find relevant documentation based on what you're working on
     - When troubleshooting mobile app integration issues
     - When planning breaking API changes
     - When writing integration tests for API endpoints
+
+- docs/features/remote-config.md
+  - Conditions:
+    - When implementing feature flags
+    - When adding new configuration values
+    - When working with Redis caching patterns
+    - When extending admin functionality
+    - When modifying mobile app configuration
+    - When working with the Config module

--- a/docs/features/remote-config.md
+++ b/docs/features/remote-config.md
@@ -1,0 +1,124 @@
+# Remote Configuration System
+
+**Date:** 2025-12-28
+**Related Files:** `Sources/App/Modules/Config/*`
+
+## Overview
+
+A remote configuration system that allows mobile apps to fetch feature flags and settings from the backend without requiring app updates. Configuration values are stored in PostgreSQL with Redis caching for performance, and can be updated by administrators through a protected API endpoint.
+
+## What Was Built
+
+- Public endpoint for mobile apps to fetch configuration (`GET /api/v1/config`)
+- Admin endpoint for updating configuration (`PUT /api/v1/admin/config`)
+- Type-safe configuration values (boolean, integer, string, JSON)
+- Redis caching with 5-minute TTL and automatic invalidation
+- Database persistence with PostgreSQL
+
+## Technical Implementation
+
+### Key Files
+
+- `Modules/Config/ConfigModule.swift`: Module registration and migration setup
+- `Modules/Config/ConfigRouter.swift`: Route definitions for public and admin endpoints
+- `Modules/Config/Controller/ConfigController.swift`: Business logic for config retrieval and updates
+- `Modules/Config/Models/Config+Model.swift`: Request/response DTOs and `AnyCodableValue` type
+- `Modules/Config/Database/Models/ConfigValueModel.swift`: Fluent database model
+- `Modules/Config/Repositories/ConfigRepository.swift`: Data access layer
+
+### Key Patterns
+
+- **Key Naming Convention**: Configuration keys use prefixes to categorize values:
+  - `featureFlags.*` for boolean feature toggles (e.g., `featureFlags.enableNewScanner`)
+  - `settings.*` for general settings (e.g., `settings.maxRetries`)
+  - `version` for config version string
+
+- **AnyCodableValue**: Type-erasing wrapper for JSON-compatible values that handles serialization of mixed types in the settings dictionary
+
+- **Cache-Through Pattern**: The controller first checks Redis cache, falls back to database on miss, and populates cache for subsequent requests
+
+- **Cache Invalidation**: Admin updates immediately delete the cached response, ensuring clients get fresh values
+
+- **Admin Authentication**: Update endpoint uses `EnsureAdminUserMiddleware` to restrict access
+
+## How to Use
+
+### Fetching Configuration (Mobile App)
+
+```http
+GET /api/v1/config
+```
+
+Response:
+```json
+{
+  "featureFlags": {
+    "enableNewScanner": true,
+    "showPromotion": false
+  },
+  "settings": {
+    "maxRetries": 3,
+    "cacheTimeoutSeconds": 300
+  },
+  "version": "1.0.0"
+}
+```
+
+### Adding New Configuration Values
+
+1. Use the admin endpoint or database migration to insert values:
+
+```json
+PUT /api/v1/admin/config
+Authorization: Bearer <admin-token>
+
+{
+  "items": [
+    {
+      "key": "featureFlags.newFeature",
+      "value": "true",
+      "valueType": "boolean"
+    },
+    {
+      "key": "settings.timeout",
+      "value": "30",
+      "valueType": "integer"
+    }
+  ]
+}
+```
+
+2. The key prefix determines where the value appears in the response:
+   - `featureFlags.*` → `featureFlags` dictionary
+   - `settings.*` → `settings` dictionary
+
+### Value Types
+
+| Type | Description | Example Value |
+|------|-------------|---------------|
+| `boolean` | True/false flags | `"true"` or `"false"` |
+| `integer` | Numeric settings | `"300"` |
+| `string` | Text values | `"production"` |
+| `json` | Complex objects | `"{\"key\": \"value\"}"` |
+
+## Configuration
+
+### Cache Settings
+
+The cache TTL is configured in `ConfigController.swift`:
+
+```swift
+private static let cacheTTL: TimeInterval = 300 // 5 minutes
+```
+
+### Redis Cache Key
+
+Config is cached under the key `config:all`.
+
+## Notes
+
+- The public endpoint requires no authentication, making it suitable for app startup configuration
+- All values are stored as strings in the database and decoded based on `valueType`
+- The `AnyCodableValue` enum provides type-safe JSON serialization for mixed-type settings
+- Cache invalidation is immediate on admin updates - no stale data window
+- The config version can be used by clients to detect when to refresh their local cache


### PR DESCRIPTION
# Remote Config Endpoint Implementation

## Summary

This PR implements a complete remote configuration system that allows mobile apps to fetch feature flags and configuration values from the backend without requiring app updates. The system provides a public GET endpoint for retrieving configuration, an admin endpoint for updating values, and uses Redis caching with PostgreSQL persistence to ensure high performance and immediate cache invalidation on updates.

## Changes

**Core Implementation**
- Added `ConfigModule` following established module patterns with proper registration in Application-Setup
- Implemented `ConfigRouter` with versioned API endpoints (`/api/v1/config` and `/api/v1/admin/config`)
- Created `ConfigController` handling both public and admin configuration endpoints

**Database & Persistence**
- Added `ConfigValueModel` with support for typed values (boolean, integer, string, JSON)
- Created migration `ConfigMigrations.v1` with unique constraint on configuration keys
- Implemented `ConfigRepository` with CRUD operations and `find(key:)` method for key-based lookups

**Caching Strategy**
- Integrated Redis caching with 5-minute TTL for the entire configuration response
- Cache-first approach: checks Redis before database queries
- Automatic cache invalidation on admin updates ensures immediate effect of configuration changes

**API Endpoints**
- **Public GET `/api/v1/config`**: No authentication required, returns structured response with `featureFlags`, `settings`, and `version` sections
- **Admin PUT `/api/v1/admin/config`**: Requires admin authentication, accepts batch updates of configuration key-value pairs with automatic cache invalidation

**Service Integration**
- Registered `ConfigRepository` in service container and Application-Setup
- Added proper OpenAPI documentation tags and endpoint descriptions

**Testing**
- Comprehensive test coverage including public endpoint access, authentication enforcement on admin endpoints, cache behavior, typed value handling, and cache invalidation on updates

## Testing

To verify the implementation:
1. Call `GET /api/v1/config` without authentication to confirm public access and proper response structure
2. Attempt `PUT /api/v1/admin/config` without authentication to verify admin protection
3. Perform an admin config update and verify cache is invalidated (subsequent requests return updated values immediately)
4. Verify typed values (boolean, integer, string, JSON) are stored and retrieved correctly
5. Confirm cache expiration after 5 minutes returns fresh database values

ADW ID: bc2ef5fc
Resolves: https://linear.app/project-rulebook/issue/RULE-151/story-12-implement-remote-config-endpoint