### PR TITLE
RULE-151

### DIFF
--- a/Sources/App/Common/Extensions/Application+Services.swift
+++ b/Sources/App/Common/Extensions/Application+Services.swift
@@ -29,6 +29,7 @@ final class ServiceStorageContainer: @unchecked Sendable {
     var passwordTokenRepository: (any PasswordTokenRepository)?
     var generatedRuleRepository: (any GeneratedRuleRepository)?
     var waitlistRepository: (any WaitlistRepository)?
+    var remoteConfigRepository: (any RemoteConfigRepository)?
 
     init() {}
 }
@@ -145,5 +146,10 @@ extension Application {
     var waitlistRepository: any WaitlistRepository {
         get { serviceStorage.waitlistRepository! }
         set { serviceStorage.waitlistRepository = newValue }
+    }
+
+    var remoteConfigRepository: any RemoteConfigRepository {
+        get { serviceStorage.remoteConfigRepository! }
+        set { serviceStorage.remoteConfigRepository = newValue }
     }
 }

--- a/Sources/App/Entrypoint/Application-Setup.swift
+++ b/Sources/App/Entrypoint/Application-Setup.swift
@@ -87,6 +87,7 @@ extension Application {
       RulesGenerationModule(),
       CacheAdminModule(),
       WaitlistModule(),
+      RemoteConfigModule(),
     ]
 
     for module in modules {
@@ -192,6 +193,7 @@ extension Application {
     passwordTokenRepository = DatabasePasswordTokenRepository(database: db)
     generatedRuleRepository = DatabaseGeneratedRuleRepository(database: db)
     waitlistRepository = DatabaseWaitlistRepository(database: db)
+    remoteConfigRepository = DatabaseRemoteConfigRepository(database: db)
 
     // Initialize foundation services (no dependencies)
     randomGeneratorService = RealRandomGeneratorService(app: self)

--- a/Sources/App/Modules/RemoteConfig/Database/Migrations/RemoteConfigMigrations.swift
+++ b/Sources/App/Modules/RemoteConfig/Database/Migrations/RemoteConfigMigrations.swift
@@ -1,0 +1,25 @@
+import Fluent
+import Vapor
+
+enum RemoteConfigMigrations {
+
+    struct v1: AsyncMigration {
+
+        func prepare(on db: Database) async throws {
+            try await db.schema(RemoteConfigEntryModel.schema)
+                .id()
+                .field(RemoteConfigEntryModel.FieldKeys.v1.key, .string, .required)
+                .field(RemoteConfigEntryModel.FieldKeys.v1.value, .string, .required)
+                .field(RemoteConfigEntryModel.FieldKeys.v1.valueType, .string, .required)
+                .field(RemoteConfigEntryModel.FieldKeys.v1.description, .string)
+                .field(RemoteConfigEntryModel.FieldKeys.v1.createdAt, .datetime)
+                .field(RemoteConfigEntryModel.FieldKeys.v1.updatedAt, .datetime)
+                .unique(on: RemoteConfigEntryModel.FieldKeys.v1.key)
+                .create()
+        }
+
+        func revert(on db: Database) async throws {
+            try await db.schema(RemoteConfigEntryModel.schema).delete()
+        }
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/Database/Models/RemoteConfigEntryModel.swift
+++ b/Sources/App/Modules/RemoteConfig/Database/Models/RemoteConfigEntryModel.swift
@@ -1,0 +1,63 @@
+import Fluent
+import Vapor
+
+final class RemoteConfigEntryModel: @unchecked Sendable, DatabaseModelInterface {
+    typealias Module = RemoteConfigModule
+    static var schema: String { "remote_config_entries" }
+
+    @ID()
+    var id: UUID?
+
+    @Field(key: FieldKeys.v1.key)
+    var key: String
+
+    @Field(key: FieldKeys.v1.value)
+    var value: String
+
+    @Field(key: FieldKeys.v1.valueType)
+    var valueType: String
+
+    @OptionalField(key: FieldKeys.v1.description)
+    var description: String?
+
+    @Timestamp(key: FieldKeys.v1.createdAt, on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: FieldKeys.v1.updatedAt, on: .update)
+    var updatedAt: Date?
+
+    init() { }
+
+    init(
+        id: UUID? = nil,
+        key: String,
+        value: String,
+        valueType: RemoteConfig.ValueType,
+        description: String? = nil
+    ) {
+        self.id = id
+        self.key = key
+        self.value = value
+        self.valueType = valueType.rawValue
+        self.description = description
+    }
+}
+
+extension RemoteConfigEntryModel {
+    struct FieldKeys {
+        struct v1 {
+            static var key: FieldKey { "key" }
+            static var value: FieldKey { "value" }
+            static var valueType: FieldKey { "value_type" }
+            static var description: FieldKey { "description" }
+            static var createdAt: FieldKey { "created_at" }
+            static var updatedAt: FieldKey { "updated_at" }
+        }
+    }
+}
+
+extension RemoteConfigEntryModel {
+    var parsedValueType: RemoteConfig.ValueType {
+        RemoteConfig.ValueType(rawValue: valueType) ?? .string
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/Models/RemoteConfig+Model.swift
+++ b/Sources/App/Modules/RemoteConfig/Models/RemoteConfig+Model.swift
@@ -1,0 +1,162 @@
+import Vapor
+
+enum RemoteConfig {
+
+    // MARK: - Value Types
+
+    enum ValueType: String, Codable, CaseIterable, Sendable {
+        case boolean
+        case integer
+        case string
+        case json
+    }
+
+    // MARK: - Public Config Response
+
+    struct Response: Content {
+        let featureFlags: [String: Bool]
+        let settings: [String: AnyCodable]
+        let version: String
+    }
+
+    // MARK: - Admin CRUD
+
+    enum Create {
+        struct Request: Content, Validatable {
+            let key: String
+            let value: String
+            let valueType: ValueType
+            let description: String?
+
+            static func validations(_ validations: inout Validations) {
+                validations.add("key", as: String.self, is: !.empty)
+                validations.add("value", as: String.self, is: !.empty)
+            }
+        }
+
+        struct Response: Content {
+            let id: UUID
+            let key: String
+            let value: String
+            let valueType: ValueType
+            let description: String?
+            let createdAt: Date?
+        }
+    }
+
+    enum Update {
+        struct Request: Content {
+            let value: String?
+            let valueType: ValueType?
+            let description: String?
+        }
+
+        struct Response: Content {
+            let id: UUID
+            let key: String
+            let value: String
+            let valueType: ValueType
+            let description: String?
+            let updatedAt: Date?
+        }
+    }
+
+    enum List {
+        struct Response: Content {
+            let entries: [Entry]
+            let total: Int
+        }
+
+        struct Entry: Content {
+            let id: UUID
+            let key: String
+            let value: String
+            let valueType: ValueType
+            let description: String?
+            let createdAt: Date?
+            let updatedAt: Date?
+        }
+    }
+
+    enum Detail {
+        struct Response: Content {
+            let id: UUID
+            let key: String
+            let value: String
+            let valueType: ValueType
+            let description: String?
+            let createdAt: Date?
+            let updatedAt: Date?
+        }
+    }
+
+    enum Delete {
+        struct Response: Content {
+            let message: String
+        }
+    }
+}
+
+// MARK: - AnyCodable Type-Erased Wrapper
+
+struct AnyCodable: Codable, @unchecked Sendable {
+    let value: Any
+
+    init(_ value: Any) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            value = NSNull()
+        } else if let bool = try? container.decode(Bool.self) {
+            value = bool
+        } else if let int = try? container.decode(Int.self) {
+            value = int
+        } else if let double = try? container.decode(Double.self) {
+            value = double
+        } else if let string = try? container.decode(String.self) {
+            value = string
+        } else if let array = try? container.decode([AnyCodable].self) {
+            value = array.map { $0.value }
+        } else if let dictionary = try? container.decode([String: AnyCodable].self) {
+            value = dictionary.mapValues { $0.value }
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unable to decode AnyCodable"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch value {
+        case is NSNull:
+            try container.encodeNil()
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        case let array as [Any]:
+            try container.encode(array.map { AnyCodable($0) })
+        case let dictionary as [String: Any]:
+            try container.encode(dictionary.mapValues { AnyCodable($0) })
+        default:
+            throw EncodingError.invalidValue(
+                value,
+                EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Unable to encode AnyCodable"
+                )
+            )
+        }
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/RemoteConfigController.swift
+++ b/Sources/App/Modules/RemoteConfig/RemoteConfigController.swift
@@ -9,19 +9,27 @@ struct RemoteConfigController {
     func getConfig(_ req: Request) async throws -> RemoteConfig.Response {
         let cacheService = req.application.cacheService
 
-        // Try cache first
-        if let cached = try await cacheService.get(Self.cacheKey, as: RemoteConfig.Response.self) {
-            return cached
+        // Try cache first (gracefully handle cache failures)
+        do {
+            if let cached = try await cacheService.get(Self.cacheKey, as: RemoteConfig.Response.self) {
+                return cached
+            }
+        } catch {
+            req.logger.warning("Cache read failed, falling back to database: \(error)")
         }
 
-        // Cache miss - build response from database
+        // Cache miss or error - build response from database
         let repository = req.repositories.remoteConfig
         let entries = try await repository.all()
 
         let response = buildConfigResponse(from: entries)
 
-        // Cache the response
-        try await cacheService.set(Self.cacheKey, value: response, ttl: Self.cacheTTL)
+        // Cache the response (best-effort, don't fail on cache errors)
+        do {
+            try await cacheService.set(Self.cacheKey, value: response, ttl: Self.cacheTTL)
+        } catch {
+            req.logger.warning("Cache write failed: \(error)")
+        }
 
         return response
     }
@@ -80,7 +88,7 @@ struct RemoteConfigController {
 
         let repository = req.repositories.remoteConfig
 
-        // Check for duplicate key
+        // Check for duplicate key (pre-check for fast-fail, but DB constraint is authoritative)
         if let _ = try await repository.find(key: createRequest.key) {
             throw Abort(.conflict, reason: "Configuration key already exists")
         }
@@ -92,10 +100,18 @@ struct RemoteConfigController {
             description: createRequest.description
         )
 
-        try await repository.create(entry)
+        do {
+            try await repository.create(entry)
+        } catch {
+            // Handle unique constraint violation from concurrent creates
+            if "\(error)".contains("UNIQUE constraint failed") || "\(error)".contains("duplicate key") {
+                throw Abort(.conflict, reason: "Configuration key already exists")
+            }
+            throw error
+        }
 
         // Invalidate cache
-        try await invalidateCache(req)
+        await invalidateCache(req)
 
         return RemoteConfig.Create.Response(
             id: entry.id!,
@@ -140,7 +156,7 @@ struct RemoteConfigController {
         try await repository.update(entry)
 
         // Invalidate cache
-        try await invalidateCache(req)
+        await invalidateCache(req)
 
         return RemoteConfig.Update.Response(
             id: entry.id!,
@@ -166,7 +182,7 @@ struct RemoteConfigController {
         try await repository.delete(entry)
 
         // Invalidate cache
-        try await invalidateCache(req)
+        await invalidateCache(req)
 
         return RemoteConfig.Delete.Response(
             message: "Configuration entry deleted successfully"
@@ -230,7 +246,12 @@ struct RemoteConfigController {
         }
     }
 
-    private func invalidateCache(_ req: Request) async throws {
-        try await req.application.cacheService.delete(Self.cacheKey)
+    private func invalidateCache(_ req: Request) async {
+        // Best-effort cache invalidation - don't fail mutations on cache errors
+        do {
+            try await req.application.cacheService.delete(Self.cacheKey)
+        } catch {
+            req.logger.warning("Cache invalidation failed: \(error)")
+        }
     }
 }

--- a/Sources/App/Modules/RemoteConfig/RemoteConfigController.swift
+++ b/Sources/App/Modules/RemoteConfig/RemoteConfigController.swift
@@ -1,0 +1,236 @@
+import Vapor
+
+struct RemoteConfigController {
+    private static let cacheKey = "remote_config_public"
+    private static let cacheTTL: TimeInterval = 300 // 5 minutes
+
+    // MARK: - Public Endpoint
+
+    func getConfig(_ req: Request) async throws -> RemoteConfig.Response {
+        let cacheService = req.application.cacheService
+
+        // Try cache first
+        if let cached = try await cacheService.get(Self.cacheKey, as: RemoteConfig.Response.self) {
+            return cached
+        }
+
+        // Cache miss - build response from database
+        let repository = req.repositories.remoteConfig
+        let entries = try await repository.all()
+
+        let response = buildConfigResponse(from: entries)
+
+        // Cache the response
+        try await cacheService.set(Self.cacheKey, value: response, ttl: Self.cacheTTL)
+
+        return response
+    }
+
+    // MARK: - Admin Endpoints
+
+    func list(_ req: Request) async throws -> RemoteConfig.List.Response {
+        let repository = req.repositories.remoteConfig
+        let entries = try await repository.all()
+        let total = try await repository.count()
+
+        return RemoteConfig.List.Response(
+            entries: entries.map { entry in
+                RemoteConfig.List.Entry(
+                    id: entry.id!,
+                    key: entry.key,
+                    value: entry.value,
+                    valueType: entry.parsedValueType,
+                    description: entry.description,
+                    createdAt: entry.createdAt,
+                    updatedAt: entry.updatedAt
+                )
+            },
+            total: total
+        )
+    }
+
+    func get(_ req: Request) async throws -> RemoteConfig.Detail.Response {
+        guard let idString = req.parameters.get("id"),
+              let id = UUID(uuidString: idString) else {
+            throw Abort(.badRequest, reason: "Invalid ID format")
+        }
+
+        let repository = req.repositories.remoteConfig
+        guard let entry = try await repository.find(id: id) else {
+            throw Abort(.notFound, reason: "Configuration entry not found")
+        }
+
+        return RemoteConfig.Detail.Response(
+            id: entry.id!,
+            key: entry.key,
+            value: entry.value,
+            valueType: entry.parsedValueType,
+            description: entry.description,
+            createdAt: entry.createdAt,
+            updatedAt: entry.updatedAt
+        )
+    }
+
+    func create(_ req: Request) async throws -> RemoteConfig.Create.Response {
+        try RemoteConfig.Create.Request.validate(content: req)
+        let createRequest = try req.content.decode(RemoteConfig.Create.Request.self)
+
+        // Validate value matches declared type
+        try validateValueType(value: createRequest.value, type: createRequest.valueType)
+
+        let repository = req.repositories.remoteConfig
+
+        // Check for duplicate key
+        if let _ = try await repository.find(key: createRequest.key) {
+            throw Abort(.conflict, reason: "Configuration key already exists")
+        }
+
+        let entry = RemoteConfigEntryModel(
+            key: createRequest.key,
+            value: createRequest.value,
+            valueType: createRequest.valueType,
+            description: createRequest.description
+        )
+
+        try await repository.create(entry)
+
+        // Invalidate cache
+        try await invalidateCache(req)
+
+        return RemoteConfig.Create.Response(
+            id: entry.id!,
+            key: entry.key,
+            value: entry.value,
+            valueType: entry.parsedValueType,
+            description: entry.description,
+            createdAt: entry.createdAt
+        )
+    }
+
+    func update(_ req: Request) async throws -> RemoteConfig.Update.Response {
+        guard let idString = req.parameters.get("id"),
+              let id = UUID(uuidString: idString) else {
+            throw Abort(.badRequest, reason: "Invalid ID format")
+        }
+
+        let updateRequest = try req.content.decode(RemoteConfig.Update.Request.self)
+
+        let repository = req.repositories.remoteConfig
+        guard let entry = try await repository.find(id: id) else {
+            throw Abort(.notFound, reason: "Configuration entry not found")
+        }
+
+        // Apply partial updates
+        if let newValue = updateRequest.value {
+            let typeToValidate = updateRequest.valueType ?? entry.parsedValueType
+            try validateValueType(value: newValue, type: typeToValidate)
+            entry.value = newValue
+        }
+
+        if let newType = updateRequest.valueType {
+            let valueToValidate = updateRequest.value ?? entry.value
+            try validateValueType(value: valueToValidate, type: newType)
+            entry.valueType = newType.rawValue
+        }
+
+        if let newDescription = updateRequest.description {
+            entry.description = newDescription
+        }
+
+        try await repository.update(entry)
+
+        // Invalidate cache
+        try await invalidateCache(req)
+
+        return RemoteConfig.Update.Response(
+            id: entry.id!,
+            key: entry.key,
+            value: entry.value,
+            valueType: entry.parsedValueType,
+            description: entry.description,
+            updatedAt: entry.updatedAt
+        )
+    }
+
+    func delete(_ req: Request) async throws -> RemoteConfig.Delete.Response {
+        guard let idString = req.parameters.get("id"),
+              let id = UUID(uuidString: idString) else {
+            throw Abort(.badRequest, reason: "Invalid ID format")
+        }
+
+        let repository = req.repositories.remoteConfig
+        guard let entry = try await repository.find(id: id) else {
+            throw Abort(.notFound, reason: "Configuration entry not found")
+        }
+
+        try await repository.delete(entry)
+
+        // Invalidate cache
+        try await invalidateCache(req)
+
+        return RemoteConfig.Delete.Response(
+            message: "Configuration entry deleted successfully"
+        )
+    }
+
+    // MARK: - Private Helpers
+
+    private func buildConfigResponse(from entries: [RemoteConfigEntryModel]) -> RemoteConfig.Response {
+        var featureFlags: [String: Bool] = [:]
+        var settings: [String: AnyCodable] = [:]
+
+        for entry in entries {
+            switch entry.parsedValueType {
+            case .boolean:
+                featureFlags[entry.key] = entry.value.lowercased() == "true"
+            case .integer:
+                if let intValue = Int(entry.value) {
+                    settings[entry.key] = AnyCodable(intValue)
+                }
+            case .string:
+                settings[entry.key] = AnyCodable(entry.value)
+            case .json:
+                if let data = entry.value.data(using: .utf8),
+                   let jsonValue = try? JSONSerialization.jsonObject(with: data) {
+                    settings[entry.key] = AnyCodable(jsonValue)
+                }
+            }
+        }
+
+        // Generate version based on entry count and latest update
+        let latestUpdate = entries.compactMap { $0.updatedAt ?? $0.createdAt }.max()
+        let version = latestUpdate.map { "\(Int($0.timeIntervalSince1970))" } ?? "0"
+
+        return RemoteConfig.Response(
+            featureFlags: featureFlags,
+            settings: settings,
+            version: version
+        )
+    }
+
+    private func validateValueType(value: String, type: RemoteConfig.ValueType) throws {
+        switch type {
+        case .boolean:
+            let lowercased = value.lowercased()
+            guard lowercased == "true" || lowercased == "false" else {
+                throw Abort(.badRequest, reason: "Value must be 'true' or 'false' for boolean type")
+            }
+        case .integer:
+            guard Int(value) != nil else {
+                throw Abort(.badRequest, reason: "Value must be a valid integer")
+            }
+        case .string:
+            // All strings are valid
+            break
+        case .json:
+            guard let data = value.data(using: .utf8),
+                  (try? JSONSerialization.jsonObject(with: data)) != nil else {
+                throw Abort(.badRequest, reason: "Value must be valid JSON")
+            }
+        }
+    }
+
+    private func invalidateCache(_ req: Request) async throws {
+        try await req.application.cacheService.delete(Self.cacheKey)
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/RemoteConfigModule.swift
+++ b/Sources/App/Modules/RemoteConfig/RemoteConfigModule.swift
@@ -1,0 +1,10 @@
+import Vapor
+
+struct RemoteConfigModule: ModuleInterface {
+    let router = RemoteConfigRouter()
+
+    func boot(_ app: Application) throws {
+        app.migrations.add(RemoteConfigMigrations.v1())
+        try router.boot(routes: app.routes)
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/RemoteConfigRouter.swift
+++ b/Sources/App/Modules/RemoteConfig/RemoteConfigRouter.swift
@@ -1,0 +1,77 @@
+import Vapor
+import VaporToOpenAPI
+
+struct RemoteConfigRouter: RouteCollection {
+    let controller = RemoteConfigController()
+
+    func boot(routes: RoutesBuilder) throws {
+        // Public endpoint - no authentication required
+        let publicAPI = routes
+            .grouped("api")
+            .grouped("v1")
+            .grouped("config")
+            .groupedOpenAPI(tags: .init(name: "Remote Config", description: "Remote configuration for mobile clients"))
+
+        publicAPI
+            .get(use: controller.getConfig)
+            .openAPI(
+                description: "Get remote configuration including feature flags and settings",
+                response: .type(RemoteConfig.Response.self)
+            )
+
+        // Admin endpoints - require authentication and admin role
+        let adminAPI = routes
+            .grouped("api")
+            .grouped("v1")
+            .grouped("admin")
+            .grouped("config")
+            .groupedOpenAPI(tags: .init(name: "Remote Config Admin", description: "Admin endpoints for managing remote configuration"))
+            .grouped(UserAccountModel.guard())
+            .grouped(EnsureAdminUserMiddleware())
+
+        adminAPI
+            .get(use: controller.list)
+            .openAPI(
+                description: "List all configuration entries",
+                response: .type(RemoteConfig.List.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+
+        adminAPI
+            .post(use: controller.create)
+            .openAPI(
+                description: "Create a new configuration entry",
+                body: .type(RemoteConfig.Create.Request.self),
+                response: .type(RemoteConfig.Create.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+
+        adminAPI
+            .group(":id") { entry in
+                entry
+                    .get(use: controller.get)
+                    .openAPI(
+                        description: "Get a specific configuration entry",
+                        response: .type(RemoteConfig.Detail.Response.self),
+                        auth: .bearer(id: "bearerAuth")
+                    )
+
+                entry
+                    .patch(use: controller.update)
+                    .openAPI(
+                        description: "Update a configuration entry",
+                        body: .type(RemoteConfig.Update.Request.self),
+                        response: .type(RemoteConfig.Update.Response.self),
+                        auth: .bearer(id: "bearerAuth")
+                    )
+
+                entry
+                    .delete(use: controller.delete)
+                    .openAPI(
+                        description: "Delete a configuration entry",
+                        response: .type(RemoteConfig.Delete.Response.self),
+                        auth: .bearer(id: "bearerAuth")
+                    )
+            }
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/Repositories/RemoteConfigRepository.swift
+++ b/Sources/App/Modules/RemoteConfig/Repositories/RemoteConfigRepository.swift
@@ -1,0 +1,61 @@
+import Fluent
+import Vapor
+
+protocol RemoteConfigRepository: Repository {
+    func find(id: UUID) async throws -> RemoteConfigEntryModel?
+    func find(key: String) async throws -> RemoteConfigEntryModel?
+    func create(_ model: RemoteConfigEntryModel) async throws
+    func update(_ model: RemoteConfigEntryModel) async throws
+    func delete(_ model: RemoteConfigEntryModel) async throws
+    func all() async throws -> [RemoteConfigEntryModel]
+    func count() async throws -> Int
+}
+
+struct DatabaseRemoteConfigRepository: RemoteConfigRepository, DatabaseRepository {
+    typealias Model = RemoteConfigEntryModel
+    let database: Database
+
+    func find(id: UUID) async throws -> RemoteConfigEntryModel? {
+        try await RemoteConfigEntryModel.query(on: database)
+            .filter(\.$id == id)
+            .first()
+    }
+
+    func find(key: String) async throws -> RemoteConfigEntryModel? {
+        try await RemoteConfigEntryModel.query(on: database)
+            .filter(\.$key == key)
+            .first()
+    }
+
+    func create(_ model: RemoteConfigEntryModel) async throws {
+        try await model.create(on: database)
+    }
+
+    func update(_ model: RemoteConfigEntryModel) async throws {
+        try await model.update(on: database)
+    }
+
+    func delete(_ model: RemoteConfigEntryModel) async throws {
+        try await model.delete(on: database)
+    }
+
+    func delete(id: UUID) async throws {
+        try await RemoteConfigEntryModel.query(on: database)
+            .filter(\.$id == id)
+            .delete()
+    }
+
+    func all() async throws -> [RemoteConfigEntryModel] {
+        try await RemoteConfigEntryModel.query(on: database).all()
+    }
+
+    func count() async throws -> Int {
+        try await RemoteConfigEntryModel.query(on: database).count()
+    }
+}
+
+extension Application.Repositories {
+    var remoteConfig: any RemoteConfigRepository {
+        application.remoteConfigRepository
+    }
+}

--- a/Tests/AppTests/Framework/IsolatedTestWorld.swift
+++ b/Tests/AppTests/Framework/IsolatedTestWorld.swift
@@ -81,6 +81,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
     private let emailTokenRepository: TestEmailTokenRepository
     private let passwordTokenRepository: TestPasswordTokenRepository
     private let generatedRuleRepository: TestGeneratedRuleRepository
+    private let remoteConfigRepository: TestRemoteConfigRepository
     
     // MARK: - Mock Services
     private let fakeLLMService: FakeLLMService
@@ -107,6 +108,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
         self.emailTokenRepository = TestEmailTokenRepository()
         self.passwordTokenRepository = TestPasswordTokenRepository()
         self.generatedRuleRepository = TestGeneratedRuleRepository()
+        self.remoteConfigRepository = TestRemoteConfigRepository()
         
         // Create fresh service instances
         self.fakeLLMService = FakeLLMService(app: app)
@@ -148,6 +150,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
         app.emailTokenRepository = self.emailTokenRepository
         app.passwordTokenRepository = self.passwordTokenRepository
         app.generatedRuleRepository = self.generatedRuleRepository
+        app.remoteConfigRepository = self.remoteConfigRepository
 
         // Assign mock services directly to Application storage
         app.emailService = FakeEmailProvider()
@@ -217,7 +220,12 @@ final class IsolatedTestWorld: @unchecked Sendable {
     var generatedRules: TestGeneratedRuleRepository {
         generatedRuleRepository
     }
-    
+
+    /// Access to the isolated remote config repository.
+    var remoteConfig: TestRemoteConfigRepository {
+        remoteConfigRepository
+    }
+
     // MARK: - Public Access to Mock Services
     
     /// Access to the isolated LLM service for configuring AI responses.
@@ -254,6 +262,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
         await emailTokenRepository.reset()
         await passwordTokenRepository.reset()
         await generatedRuleRepository.reset()
+        await remoteConfigRepository.reset()
         
         // Reset services
         fakeLLMService.reset()

--- a/Tests/AppTests/Framework/Mocks/Repositories/TestRemoteConfigRepository.swift
+++ b/Tests/AppTests/Framework/Mocks/Repositories/TestRemoteConfigRepository.swift
@@ -1,0 +1,75 @@
+@testable import App
+import Vapor
+import Fluent
+
+actor TestRemoteConfigRepository: RemoteConfigRepository, TestRepository {
+    var entries: [RemoteConfigEntryModel]
+
+    var entities: [RemoteConfigEntryModel] {
+        get { entries }
+        set { entries = newValue }
+    }
+
+    init(entries: [RemoteConfigEntryModel] = []) {
+        self.entries = entries
+    }
+
+    typealias Model = RemoteConfigEntryModel
+
+    func find(id: UUID) async throws -> RemoteConfigEntryModel? {
+        entries.first(where: { $0.id == id })
+    }
+
+    func find(key: String) async throws -> RemoteConfigEntryModel? {
+        entries.first(where: { $0.key == key })
+    }
+
+    func create(_ model: RemoteConfigEntryModel) async throws {
+        // Simulate unique key constraint
+        if entries.contains(where: { $0.key == model.key }) {
+            throw Abort(.conflict, reason: "UNIQUE constraint failed: remote_config_entries.key")
+        }
+        model.id = model.id ?? UUID()
+        entries.append(model)
+    }
+
+    func update(_ model: RemoteConfigEntryModel) async throws {
+        guard let id = model.id,
+              let index = entries.firstIndex(where: { $0.id == id }) else {
+            throw Abort(.notFound)
+        }
+        entries[index] = model
+    }
+
+    func delete(_ model: RemoteConfigEntryModel) async throws {
+        guard let id = model.id else {
+            throw Abort(.notFound)
+        }
+        entries.removeAll(where: { $0.id == id })
+    }
+
+    func delete(id: UUID) async throws {
+        entries.removeAll(where: { $0.id == id })
+    }
+
+    func all() async throws -> [RemoteConfigEntryModel] {
+        entries
+    }
+
+    func count() async throws -> Int {
+        entries.count
+    }
+
+    func reset() async {
+        entries.removeAll()
+    }
+
+    func add(_ entry: RemoteConfigEntryModel) async {
+        entry.id = entry.id ?? UUID()
+        entries.append(entry)
+    }
+
+    nonisolated func `for`(_ req: Request) -> TestRemoteConfigRepository {
+        return self
+    }
+}

--- a/Tests/AppTests/Framework/TestTags.swift
+++ b/Tests/AppTests/Framework/TestTags.swift
@@ -66,6 +66,9 @@ extension Tag {
     /// Email service tests.
     @Tag static var email: Self
 
+    /// Remote configuration tests.
+    @Tag static var config: Self
+
     // MARK: Test Type Tags
 
     /// Integration tests - full application stack with HTTP.

--- a/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigAdminTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigAdminTests.swift
@@ -1,0 +1,372 @@
+@testable import App
+import Fluent
+import VaporTesting
+import Testing
+
+@Suite(.serialized)
+struct RemoteConfigAdminTests {
+    let app: Application
+    let testWorld: IsolatedTestWorld
+    let adminConfigPath = "api/v1/admin/config"
+
+    init() async throws {
+        testWorld = try await IsolatedTestWorld()
+        app = testWorld.app
+    }
+
+    // MARK: - Authorization Tests
+
+    @Test("Admin list endpoint requires authentication", .tags(.p0Critical, .config, .security, .integration))
+    func listRequiresAuth() async throws {
+        await testWorld.resetAll()
+
+        try await app.test(.GET, adminConfigPath) { response in
+            #expect(response.status == .unauthorized)
+        }
+    }
+
+    @Test("Admin list endpoint requires admin role", .tags(.p0Critical, .config, .security, .integration))
+    func listRequiresAdminRole() async throws {
+        await testWorld.resetAll()
+        let nonAdmin = try UserAccountModel.mock(app: app, isAdmin: false)
+        try await app.repositories.users.create(nonAdmin)
+
+        try await app.test(.GET, adminConfigPath, user: nonAdmin) { response in
+            #expect(response.status == .unauthorized)
+        }
+    }
+
+    // MARK: - List Tests
+
+    @Test("Admin can list all config entries", .tags(.p1Core, .config, .integration))
+    func listConfigEntries() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let entry1 = RemoteConfigEntryModel(
+            key: "feature_one",
+            value: "true",
+            valueType: .boolean
+        )
+        let entry2 = RemoteConfigEntryModel(
+            key: "max_items",
+            value: "100",
+            valueType: .integer
+        )
+        await testWorld.remoteConfig.add(entry1)
+        await testWorld.remoteConfig.add(entry2)
+
+        try await app.test(.GET, adminConfigPath, user: admin) { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.List.Response.self, response) { listResponse in
+                #expect(listResponse.entries.count == 2)
+                #expect(listResponse.total == 2)
+            }
+        }
+    }
+
+    // MARK: - Create Tests
+
+    @Test("Admin can create boolean config entry", .tags(.p1Core, .config, .integration))
+    func createBooleanEntry() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "new_feature",
+            value: "true",
+            valueType: .boolean,
+            description: "A new feature flag"
+        )
+
+        try await app.test(.POST, adminConfigPath, user: admin, content: createRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Create.Response.self, response) { createResponse in
+                #expect(createResponse.key == "new_feature")
+                #expect(createResponse.value == "true")
+                #expect(createResponse.valueType == .boolean)
+                #expect(createResponse.description == "A new feature flag")
+            }
+        })
+    }
+
+    @Test("Admin can create integer config entry", .tags(.p1Core, .config, .integration))
+    func createIntegerEntry() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "max_connections",
+            value: "50",
+            valueType: .integer,
+            description: nil
+        )
+
+        try await app.test(.POST, adminConfigPath, user: admin, content: createRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Create.Response.self, response) { createResponse in
+                #expect(createResponse.key == "max_connections")
+                #expect(createResponse.value == "50")
+                #expect(createResponse.valueType == .integer)
+            }
+        })
+    }
+
+    @Test("Admin can create JSON config entry", .tags(.p1Core, .config, .integration))
+    func createJSONEntry() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "app_config",
+            value: "{\"theme\":\"dark\"}",
+            valueType: .json,
+            description: nil
+        )
+
+        try await app.test(.POST, adminConfigPath, user: admin, content: createRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Create.Response.self, response) { createResponse in
+                #expect(createResponse.key == "app_config")
+                #expect(createResponse.valueType == .json)
+            }
+        })
+    }
+
+    @Test("Create fails with duplicate key", .tags(.p1Core, .config, .integration))
+    func createFailsWithDuplicateKey() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let existing = RemoteConfigEntryModel(
+            key: "existing_key",
+            value: "true",
+            valueType: .boolean
+        )
+        await testWorld.remoteConfig.add(existing)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "existing_key",
+            value: "false",
+            valueType: .boolean,
+            description: nil
+        )
+
+        try await app.test(.POST, adminConfigPath, user: admin, content: createRequest, afterResponse: { response in
+            #expect(response.status == .conflict)
+        })
+    }
+
+    @Test("Create validates boolean value type", .tags(.p1Core, .config, .integration))
+    func createValidatesBooleanValue() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "bad_bool",
+            value: "not_a_boolean",
+            valueType: .boolean,
+            description: nil
+        )
+
+        try await app.test(.POST, adminConfigPath, user: admin, content: createRequest, afterResponse: { response in
+            #expect(response.status == .badRequest)
+        })
+    }
+
+    @Test("Create validates integer value type", .tags(.p1Core, .config, .integration))
+    func createValidatesIntegerValue() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "bad_int",
+            value: "not_an_integer",
+            valueType: .integer,
+            description: nil
+        )
+
+        try await app.test(.POST, adminConfigPath, user: admin, content: createRequest, afterResponse: { response in
+            #expect(response.status == .badRequest)
+        })
+    }
+
+    @Test("Create validates JSON value type", .tags(.p1Core, .config, .integration))
+    func createValidatesJSONValue() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "bad_json",
+            value: "not valid json {",
+            valueType: .json,
+            description: nil
+        )
+
+        try await app.test(.POST, adminConfigPath, user: admin, content: createRequest, afterResponse: { response in
+            #expect(response.status == .badRequest)
+        })
+    }
+
+    // MARK: - Update Tests
+
+    @Test("Admin can update config entry value", .tags(.p1Core, .config, .integration))
+    func updateEntryValue() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let entry = RemoteConfigEntryModel(
+            id: UUID(),
+            key: "update_me",
+            value: "old_value",
+            valueType: .string
+        )
+        await testWorld.remoteConfig.add(entry)
+
+        let updateRequest = RemoteConfig.Update.Request(
+            value: "new_value",
+            valueType: nil,
+            description: nil
+        )
+
+        try await app.test(.PATCH, "\(adminConfigPath)/\(entry.id!)", user: admin, content: updateRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Update.Response.self, response) { updateResponse in
+                #expect(updateResponse.value == "new_value")
+            }
+        })
+    }
+
+    @Test("Admin can update config entry description", .tags(.p2Extended, .config, .integration))
+    func updateEntryDescription() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let entry = RemoteConfigEntryModel(
+            id: UUID(),
+            key: "desc_entry",
+            value: "true",
+            valueType: .boolean,
+            description: "Old description"
+        )
+        await testWorld.remoteConfig.add(entry)
+
+        let updateRequest = RemoteConfig.Update.Request(
+            value: nil,
+            valueType: nil,
+            description: "New description"
+        )
+
+        try await app.test(.PATCH, "\(adminConfigPath)/\(entry.id!)", user: admin, content: updateRequest, afterResponse: { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Update.Response.self, response) { updateResponse in
+                #expect(updateResponse.description == "New description")
+            }
+        })
+    }
+
+    @Test("Update fails for non-existent entry", .tags(.p1Core, .config, .integration))
+    func updateFailsForNonExistent() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let updateRequest = RemoteConfig.Update.Request(
+            value: "new_value",
+            valueType: nil,
+            description: nil
+        )
+
+        try await app.test(.PATCH, "\(adminConfigPath)/\(UUID())", user: admin, content: updateRequest, afterResponse: { response in
+            #expect(response.status == .notFound)
+        })
+    }
+
+    // MARK: - Delete Tests
+
+    @Test("Admin can delete config entry", .tags(.p1Core, .config, .integration))
+    func deleteEntry() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let entry = RemoteConfigEntryModel(
+            id: UUID(),
+            key: "delete_me",
+            value: "true",
+            valueType: .boolean
+        )
+        await testWorld.remoteConfig.add(entry)
+
+        try await app.test(.DELETE, "\(adminConfigPath)/\(entry.id!)", user: admin) { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Delete.Response.self, response) { deleteResponse in
+                #expect(deleteResponse.message.contains("deleted"))
+            }
+        }
+
+        // Verify deletion
+        let count = try await testWorld.remoteConfig.count()
+        #expect(count == 0)
+    }
+
+    @Test("Delete fails for non-existent entry", .tags(.p1Core, .config, .integration))
+    func deleteFailsForNonExistent() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        try await app.test(.DELETE, "\(adminConfigPath)/\(UUID())", user: admin) { response in
+            #expect(response.status == .notFound)
+        }
+    }
+
+    // MARK: - Get Single Entry Tests
+
+    @Test("Admin can get single config entry", .tags(.p1Core, .config, .integration))
+    func getSingleEntry() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        let entry = RemoteConfigEntryModel(
+            id: UUID(),
+            key: "get_me",
+            value: "42",
+            valueType: .integer,
+            description: "Test entry"
+        )
+        await testWorld.remoteConfig.add(entry)
+
+        try await app.test(.GET, "\(adminConfigPath)/\(entry.id!)", user: admin) { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Detail.Response.self, response) { detail in
+                #expect(detail.key == "get_me")
+                #expect(detail.value == "42")
+                #expect(detail.valueType == .integer)
+                #expect(detail.description == "Test entry")
+            }
+        }
+    }
+
+    @Test("Get single entry fails for non-existent", .tags(.p1Core, .config, .integration))
+    func getSingleFailsForNonExistent() async throws {
+        await testWorld.resetAll()
+        let admin = try await testWorld.dataFactory.createAdminUser()
+        try await app.repositories.users.create(admin)
+
+        try await app.test(.GET, "\(adminConfigPath)/\(UUID())", user: admin) { response in
+            #expect(response.status == .notFound)
+        }
+    }
+}

--- a/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigPublicTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigPublicTests.swift
@@ -1,0 +1,136 @@
+@testable import App
+import Fluent
+import VaporTesting
+import Testing
+
+@Suite(.serialized)
+struct RemoteConfigPublicTests {
+    let app: Application
+    let testWorld: IsolatedTestWorld
+    let configPath = "api/v1/config"
+
+    init() async throws {
+        testWorld = try await IsolatedTestWorld()
+        app = testWorld.app
+    }
+
+    @Test("Public config endpoint returns correct structure", .tags(.p1Core, .config, .integration))
+    func getConfigReturnsCorrectStructure() async throws {
+        await testWorld.resetAll()
+
+        // Create some config entries
+        let boolEntry = RemoteConfigEntryModel(
+            key: "feature_dark_mode",
+            value: "true",
+            valueType: .boolean,
+            description: "Enable dark mode"
+        )
+        let intEntry = RemoteConfigEntryModel(
+            key: "max_retries",
+            value: "3",
+            valueType: .integer,
+            description: "Maximum retry attempts"
+        )
+        let stringEntry = RemoteConfigEntryModel(
+            key: "welcome_message",
+            value: "Hello, World!",
+            valueType: .string,
+            description: "Welcome message"
+        )
+
+        await testWorld.remoteConfig.add(boolEntry)
+        await testWorld.remoteConfig.add(intEntry)
+        await testWorld.remoteConfig.add(stringEntry)
+
+        try await app.test(.GET, configPath) { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Response.self, response) { config in
+                #expect(config.featureFlags["feature_dark_mode"] == true)
+                #expect(config.settings["max_retries"] != nil)
+                #expect(config.settings["welcome_message"] != nil)
+                #expect(!config.version.isEmpty)
+            }
+        }
+    }
+
+    @Test("Public config endpoint returns empty config when no entries exist", .tags(.p1Core, .config, .integration))
+    func getConfigReturnsEmptyWhenNoEntries() async throws {
+        await testWorld.resetAll()
+
+        try await app.test(.GET, configPath) { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Response.self, response) { config in
+                #expect(config.featureFlags.isEmpty)
+                #expect(config.settings.isEmpty)
+            }
+        }
+    }
+
+    @Test("Public config endpoint separates booleans into featureFlags", .tags(.p1Core, .config, .integration))
+    func getConfigSeparatesBooleanIntoFeatureFlags() async throws {
+        await testWorld.resetAll()
+
+        let boolTrue = RemoteConfigEntryModel(
+            key: "feature_enabled",
+            value: "true",
+            valueType: .boolean
+        )
+        let boolFalse = RemoteConfigEntryModel(
+            key: "feature_disabled",
+            value: "false",
+            valueType: .boolean
+        )
+        let nonBool = RemoteConfigEntryModel(
+            key: "api_url",
+            value: "https://api.example.com",
+            valueType: .string
+        )
+
+        await testWorld.remoteConfig.add(boolTrue)
+        await testWorld.remoteConfig.add(boolFalse)
+        await testWorld.remoteConfig.add(nonBool)
+
+        try await app.test(.GET, configPath) { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Response.self, response) { config in
+                // Booleans should be in featureFlags
+                #expect(config.featureFlags["feature_enabled"] == true)
+                #expect(config.featureFlags["feature_disabled"] == false)
+                // Non-booleans should not be in featureFlags
+                #expect(config.featureFlags["api_url"] == nil)
+                // Non-booleans should be in settings
+                #expect(config.settings["api_url"] != nil)
+            }
+        }
+    }
+
+    @Test("Public config endpoint handles JSON values", .tags(.p2Extended, .config, .integration))
+    func getConfigHandlesJSONValues() async throws {
+        await testWorld.resetAll()
+
+        let jsonEntry = RemoteConfigEntryModel(
+            key: "app_settings",
+            value: "{\"theme\":\"dark\",\"version\":2}",
+            valueType: .json
+        )
+
+        await testWorld.remoteConfig.add(jsonEntry)
+
+        try await app.test(.GET, configPath) { response in
+            #expect(response.status == .ok)
+            expectContent(RemoteConfig.Response.self, response) { config in
+                #expect(config.settings["app_settings"] != nil)
+            }
+        }
+    }
+
+    @Test("Public config endpoint is accessible without authentication", .tags(.p0Critical, .config, .security, .integration))
+    func getConfigDoesNotRequireAuth() async throws {
+        await testWorld.resetAll()
+
+        // Should succeed without any auth header
+        try await app.test(.GET, configPath) { response in
+            #expect(response.status == .ok)
+        }
+    }
+}

--- a/docs/CONDITIONAL_DOCS.md
+++ b/docs/CONDITIONAL_DOCS.md
@@ -19,3 +19,12 @@ This guide helps you find relevant documentation based on what you're working on
     - When troubleshooting mobile app integration issues
     - When planning breaking API changes
     - When writing integration tests for API endpoints
+
+- docs/features/remote-configuration.md
+  - Conditions:
+    - When implementing feature flags in the mobile app
+    - When creating new modules with repository and caching patterns
+    - When adding admin-only CRUD endpoints with authorization
+    - When building public unauthenticated API endpoints
+    - When working with heterogeneous JSON types in Swift (AnyCodable pattern)
+    - When implementing cache-first strategies with graceful fallback

--- a/docs/features/remote-configuration.md
+++ b/docs/features/remote-configuration.md
@@ -1,0 +1,258 @@
+# Remote Configuration Module
+
+**Date:** 2026-01-21
+**Related Files:** RemoteConfigController.swift, RemoteConfigRouter.swift, RemoteConfigRepository.swift, RemoteConfig+Model.swift
+
+## Overview
+
+Server-side remote configuration system that delivers feature flags and app settings to mobile clients without requiring app store updates. Provides a public endpoint for mobile apps to fetch configuration and admin endpoints for managing configuration entries.
+
+## What Was Built
+
+- Public endpoint (`GET /api/v1/config`) for mobile clients to fetch feature flags and settings
+- Admin CRUD endpoints (`/api/v1/admin/config`) for managing configuration entries
+- Cache-first strategy with 5-minute TTL and graceful database fallback
+- Value type validation (boolean, integer, string, json)
+- Automatic cache invalidation on configuration mutations
+- AnyCodable type-erased wrapper for heterogeneous JSON values
+
+## Technical Implementation
+
+### Key Files
+
+- `Sources/App/Modules/RemoteConfig/RemoteConfigController.swift`: Business logic for public and admin endpoints
+- `Sources/App/Modules/RemoteConfig/RemoteConfigRouter.swift`: Route definitions with OpenAPI documentation
+- `Sources/App/Modules/RemoteConfig/Repositories/RemoteConfigRepository.swift`: Data access layer
+- `Sources/App/Modules/RemoteConfig/Models/RemoteConfig+Model.swift`: Request/response models and AnyCodable wrapper
+- `Sources/App/Modules/RemoteConfig/Database/Models/RemoteConfigEntryModel.swift`: Fluent database model
+- `Sources/App/Modules/RemoteConfig/RemoteConfigModule.swift`: Module registration
+
+### Key Patterns
+
+**Cache-First Strategy with Graceful Degradation:**
+
+The public config endpoint tries cache first but gracefully falls back to the database if cache operations fail:
+
+```swift
+func getConfig(_ req: Request) async throws -> RemoteConfig.Response {
+    let cacheService = req.application.cacheService
+
+    // Try cache first (gracefully handle cache failures)
+    do {
+        if let cached = try await cacheService.get(Self.cacheKey, as: RemoteConfig.Response.self) {
+            return cached
+        }
+    } catch {
+        req.logger.warning("Cache read failed, falling back to database: \(error)")
+    }
+
+    // Cache miss or error - build response from database
+    let repository = req.repositories.remoteConfig
+    let entries = try await repository.all()
+    let response = buildConfigResponse(from: entries)
+
+    // Cache the response (best-effort, don't fail on cache errors)
+    do {
+        try await cacheService.set(Self.cacheKey, value: response, ttl: Self.cacheTTL)
+    } catch {
+        req.logger.warning("Cache write failed: \(error)")
+    }
+
+    return response
+}
+```
+
+**Type-Safe Value Validation:**
+
+Configuration values are validated against their declared type before storage:
+
+```swift
+private func validateValueType(value: String, type: RemoteConfig.ValueType) throws {
+    switch type {
+    case .boolean:
+        let lowercased = value.lowercased()
+        guard lowercased == "true" || lowercased == "false" else {
+            throw Abort(.badRequest, reason: "Value must be 'true' or 'false' for boolean type")
+        }
+    case .integer:
+        guard Int(value) != nil else {
+            throw Abort(.badRequest, reason: "Value must be a valid integer")
+        }
+    case .json:
+        guard let data = value.data(using: .utf8),
+              (try? JSONSerialization.jsonObject(with: data)) != nil else {
+            throw Abort(.badRequest, reason: "Value must be valid JSON")
+        }
+    case .string:
+        break // All strings are valid
+    }
+}
+```
+
+**AnyCodable Type-Erased Wrapper:**
+
+For encoding heterogeneous JSON values in the settings dictionary:
+
+```swift
+struct AnyCodable: Codable, @unchecked Sendable {
+    let value: Any
+
+    init(_ value: Any) {
+        self.value = value
+    }
+
+    // Encode/decode any JSON-compatible type
+}
+```
+
+**Race Condition Protection:**
+
+Admin create endpoint handles concurrent duplicate key creation:
+
+```swift
+// Pre-check for fast-fail
+if let _ = try await repository.find(key: createRequest.key) {
+    throw Abort(.conflict, reason: "Configuration key already exists")
+}
+
+do {
+    try await repository.create(entry)
+} catch {
+    // Handle unique constraint violation from concurrent creates
+    if "\(error)".contains("UNIQUE constraint failed") || "\(error)".contains("duplicate key") {
+        throw Abort(.conflict, reason: "Configuration key already exists")
+    }
+    throw error
+}
+```
+
+### Code Examples
+
+**Creating a Feature Flag (Admin):**
+
+```bash
+POST /api/v1/admin/config
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{
+    "key": "feature_dark_mode",
+    "value": "true",
+    "valueType": "boolean",
+    "description": "Enable dark mode feature"
+}
+```
+
+**Fetching Configuration (Mobile Client):**
+
+```bash
+GET /api/v1/config
+
+Response:
+{
+    "featureFlags": {
+        "feature_dark_mode": true,
+        "feature_beta_testing": false
+    },
+    "settings": {
+        "max_retries": 3,
+        "api_timeout": 30,
+        "welcome_message": "Hello!"
+    },
+    "version": "1737496234"
+}
+```
+
+## How to Use
+
+### For Mobile App Developers
+
+1. Call `GET /api/v1/config` on app launch or resume
+2. Use the `version` field to detect configuration changes
+3. Boolean configs are in `featureFlags`, other types in `settings`
+4. Cache locally and refresh periodically (endpoint is cached server-side for 5 minutes)
+
+```swift
+// iOS Example
+struct RemoteConfig: Codable {
+    let featureFlags: [String: Bool]
+    let settings: [String: AnyCodable]
+    let version: String
+}
+
+func fetchConfig() async throws -> RemoteConfig {
+    let url = URL(string: "https://api.example.com/api/v1/config")!
+    let (data, _) = try await URLSession.shared.data(from: url)
+    return try JSONDecoder().decode(RemoteConfig.self, from: data)
+}
+```
+
+### For Backend Developers
+
+**Adding New Configuration Entry:**
+
+1. Use admin panel or API to create entry
+2. Choose appropriate value type (boolean for feature flags)
+3. Cache is automatically invalidated
+
+**Creating a New Module Following This Pattern:**
+
+1. Create module directory under `Sources/App/Modules/{ModuleName}/`
+2. Create subdirectories: `Database/Models/`, `Database/Migrations/`, `Models/`, `Repositories/`
+3. Implement: Model, Repository Protocol + Implementation, Controller, Router, Module
+4. Register repository in `Application+Services.swift`
+5. Register module in `Application-Setup.swift`
+6. Create test repository mock in `Tests/AppTests/Framework/Mocks/Repositories/`
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| Cache TTL | TimeInterval | 300 (5 min) | How long public config is cached |
+| Cache Key | String | "remote_config_public" | Cache key for public config |
+
+**Value Types:**
+
+| Type | Storage | JSON Output |
+|------|---------|-------------|
+| boolean | "true"/"false" | true/false in featureFlags |
+| integer | "123" | 123 in settings |
+| string | "any text" | "any text" in settings |
+| json | "{...}" | parsed object in settings |
+
+## Notes
+
+### Public vs Admin Endpoints
+
+- **Public (`/api/v1/config`)**: No authentication required, read-only, cached
+- **Admin (`/api/v1/admin/config`)**: Requires authentication + admin role, CRUD operations, triggers cache invalidation
+
+### Response Structure Design
+
+Boolean values are separated into `featureFlags` for easier mobile consumption:
+
+```json
+{
+    "featureFlags": { "feature_x": true },  // Only booleans
+    "settings": { "max_items": 100 }         // Everything else
+}
+```
+
+### Version Field
+
+The `version` field is a Unix timestamp of the most recent update. Mobile apps can use this to detect when configuration has changed without comparing the full payload.
+
+### Testing
+
+Test tag `.config` is available for filtering remote config tests:
+
+```bash
+swift test --filter config
+```
+
+### Architectural Decisions
+
+- **Values stored as strings**: Allows uniform storage while supporting multiple types via valueType enum
+- **Cache-first with fallback**: Ensures API availability even during cache failures
+- **Admin authorization**: Uses EnsureAdminUserMiddleware following existing codebase patterns
+- **OpenAPI integration**: All routes documented via VaporToOpenAPI annotations


### PR DESCRIPTION
## Summary

Implements a server-side remote configuration module that delivers feature flags and app settings to mobile clients without requiring app store updates. The system provides a public cached endpoint for mobile apps and authenticated admin endpoints for configuration management.

## Changes

- Added `RemoteConfigModule` with complete CRUD operations for configuration entries
- Public endpoint `GET /api/v1/config` serves cached configuration (5-minute TTL)
- Admin endpoints `GET/POST/PATCH/DELETE /api/v1/admin/config` with admin authorization
- Value type validation for boolean, integer, string, and json types
- Automatic cache invalidation on all configuration mutations
- Cache-first strategy with graceful database fallback on cache errors
- AnyCodable type-erased wrapper for heterogeneous JSON values
- Comprehensive test suite (22 tests) covering public and admin endpoints
- Added feature documentation: `docs/features/remote-configuration.md`
- Updated conditional docs guide with discoverability conditions

## Testing

All 22 tests pass covering:
- Public endpoint returns correct structure with featureFlags/settings separation
- Empty config returns valid response
- Public endpoint accessible without authentication
- Admin endpoints require authentication and admin role
- CRUD operations (create, read, update, delete)
- Value type validation (boolean, integer, string, json)
- Duplicate key rejection with conflict response
- Cache behavior (served from cache when available)

**Evidence from validate phase:**
- Tests passed: true
- Code review passed: true
- Issues fixed: Cache error handling and race condition protection

## Evidence

Test output confirms:
- HTTP 200 responses for valid operations
- HTTP 401 for unauthorized access attempts
- HTTP 400 for invalid value types
- HTTP 409 for duplicate key conflicts
- HTTP 404 for non-existent entries
