### PR TITLE
RULE-151: Story 1.2: Implement Remote Config Endpoint

### DIFF
--- a/Sources/App/Common/Extensions/Application+Services.swift
+++ b/Sources/App/Common/Extensions/Application+Services.swift
@@ -29,6 +29,7 @@ final class ServiceStorageContainer: @unchecked Sendable {
     var passwordTokenRepository: (any PasswordTokenRepository)?
     var generatedRuleRepository: (any GeneratedRuleRepository)?
     var waitlistRepository: (any WaitlistRepository)?
+    var remoteConfigRepository: (any RemoteConfigRepository)?
 
     init() {}
 }
@@ -145,5 +146,10 @@ extension Application {
     var waitlistRepository: any WaitlistRepository {
         get { serviceStorage.waitlistRepository! }
         set { serviceStorage.waitlistRepository = newValue }
+    }
+
+    var remoteConfigRepository: any RemoteConfigRepository {
+        get { serviceStorage.remoteConfigRepository! }
+        set { serviceStorage.remoteConfigRepository = newValue }
     }
 }

--- a/Sources/App/Entrypoint/Application-Setup.swift
+++ b/Sources/App/Entrypoint/Application-Setup.swift
@@ -87,6 +87,7 @@ extension Application {
       RulesGenerationModule(),
       CacheAdminModule(),
       WaitlistModule(),
+      RemoteConfigModule(),
     ]
 
     for module in modules {
@@ -192,6 +193,7 @@ extension Application {
     passwordTokenRepository = DatabasePasswordTokenRepository(database: db)
     generatedRuleRepository = DatabaseGeneratedRuleRepository(database: db)
     waitlistRepository = DatabaseWaitlistRepository(database: db)
+    remoteConfigRepository = DatabaseRemoteConfigRepository(database: db)
 
     // Initialize foundation services (no dependencies)
     randomGeneratorService = RealRandomGeneratorService(app: self)

--- a/Sources/App/Modules/RemoteConfig/Controller/RemoteConfigController.swift
+++ b/Sources/App/Modules/RemoteConfig/Controller/RemoteConfigController.swift
@@ -1,0 +1,240 @@
+import Vapor
+
+struct RemoteConfigController {
+
+    /// Cache key for the entire remote config response.
+    private static let cacheKey = "remote_config_all"
+
+    /// Cache TTL in seconds (5 minutes).
+    private static let cacheTTL: TimeInterval = 300
+
+    // MARK: - Public Endpoint
+
+    func getConfig(_ req: Request) async throws -> RemoteConfig.Get.Response {
+        // Check cache first
+        if let cached = try await req.services.cache.get(Self.cacheKey, as: RemoteConfig.Get.Response.self) {
+            req.logger.debug("Cache hit for remote config")
+            return cached
+        }
+
+        req.logger.debug("Cache miss for remote config, fetching from database")
+
+        // Fetch from database
+        let repository = req.repositories.remoteConfig
+        let entries = try await repository.findAll()
+
+        // Transform to response format
+        let response = transformToResponse(entries)
+
+        // Cache the response
+        try await req.services.cache.set(Self.cacheKey, value: response, ttl: Self.cacheTTL)
+
+        return response
+    }
+
+    // MARK: - Admin Endpoints
+
+    func listAllConfig(_ req: Request) async throws -> RemoteConfig.List.Response {
+        let repository = req.repositories.remoteConfig
+        let entries = try await repository.findAll()
+
+        let responseEntries = entries.map { entry in
+            RemoteConfig.List.Entry(
+                id: entry.id!,
+                key: entry.key,
+                value: entry.value,
+                valueType: entry.valueType.rawValue,
+                createdAt: entry.createdAt,
+                updatedAt: entry.updatedAt
+            )
+        }
+
+        return RemoteConfig.List.Response(entries: responseEntries)
+    }
+
+    func createConfig(_ req: Request) async throws -> RemoteConfig.Create.Response {
+        try RemoteConfig.Create.Request.validate(content: req)
+        let createRequest = try req.content.decode(RemoteConfig.Create.Request.self)
+
+        let repository = req.repositories.remoteConfig
+
+        // Check if key already exists
+        if try await repository.find(key: createRequest.key) != nil {
+            throw Abort(.conflict, reason: "Configuration key '\(createRequest.key)' already exists")
+        }
+
+        guard let valueType = ConfigValueType(rawValue: createRequest.valueType) else {
+            throw Abort(.badRequest, reason: "Invalid value type: \(createRequest.valueType)")
+        }
+
+        // Validate value matches type
+        try validateValueMatchesType(createRequest.value, type: valueType)
+
+        let model = RemoteConfigModel(
+            key: createRequest.key,
+            value: createRequest.value,
+            valueType: valueType
+        )
+
+        try await repository.create(model)
+
+        // Invalidate cache
+        try await invalidateCache(req)
+
+        return RemoteConfig.Create.Response(
+            id: model.id!,
+            key: model.key,
+            value: model.value,
+            valueType: model.valueType.rawValue,
+            message: "Configuration entry created successfully"
+        )
+    }
+
+    func updateConfig(_ req: Request) async throws -> RemoteConfig.Update.Response {
+        guard let key = req.parameters.get("key") else {
+            throw Abort(.badRequest, reason: "Missing configuration key")
+        }
+
+        try RemoteConfig.Update.Request.validate(content: req)
+        let updateRequest = try req.content.decode(RemoteConfig.Update.Request.self)
+
+        let repository = req.repositories.remoteConfig
+
+        guard let model = try await repository.find(key: key) else {
+            throw Abort(.notFound, reason: "Configuration key '\(key)' not found")
+        }
+
+        // Determine value type (use existing if not provided)
+        let valueType: ConfigValueType
+        if let newTypeString = updateRequest.valueType,
+           let newType = ConfigValueType(rawValue: newTypeString) {
+            valueType = newType
+        } else {
+            valueType = model.valueType
+        }
+
+        // Validate value matches type
+        try validateValueMatchesType(updateRequest.value, type: valueType)
+
+        model.value = updateRequest.value
+        model.valueType = valueType
+
+        try await repository.update(model)
+
+        // Invalidate cache
+        try await invalidateCache(req)
+
+        return RemoteConfig.Update.Response(
+            id: model.id!,
+            key: model.key,
+            value: model.value,
+            valueType: model.valueType.rawValue,
+            message: "Configuration entry updated successfully"
+        )
+    }
+
+    func deleteConfig(_ req: Request) async throws -> RemoteConfig.Delete.Response {
+        guard let key = req.parameters.get("key") else {
+            throw Abort(.badRequest, reason: "Missing configuration key")
+        }
+
+        let repository = req.repositories.remoteConfig
+
+        guard let model = try await repository.find(key: key) else {
+            throw Abort(.notFound, reason: "Configuration key '\(key)' not found")
+        }
+
+        try await repository.delete(model)
+
+        // Invalidate cache
+        try await invalidateCache(req)
+
+        return RemoteConfig.Delete.Response(
+            key: key,
+            message: "Configuration entry deleted successfully"
+        )
+    }
+
+    // MARK: - Private Helpers
+
+    /// Transforms database entries into the public response format.
+    private func transformToResponse(_ entries: [RemoteConfigModel]) -> RemoteConfig.Get.Response {
+        var featureFlags: [String: Bool] = [:]
+        var settings: [String: AnyCodableValue] = [:]
+
+        for entry in entries {
+            // Parse key to determine category
+            let parts = entry.key.split(separator: ".", maxSplits: 1)
+
+            if parts.count == 2 {
+                let category = String(parts[0])
+                let name = String(parts[1])
+
+                switch category {
+                case "featureFlags":
+                    if entry.valueType == .boolean {
+                        featureFlags[name] = entry.value.lowercased() == "true"
+                    }
+                case "settings":
+                    switch entry.valueType {
+                    case .boolean:
+                        settings[name] = .bool(entry.value.lowercased() == "true")
+                    case .integer:
+                        settings[name] = .int(Int(entry.value) ?? 0)
+                    case .string:
+                        settings[name] = .string(entry.value)
+                    }
+                default:
+                    // Unknown category - add to settings
+                    switch entry.valueType {
+                    case .boolean:
+                        settings[entry.key] = .bool(entry.value.lowercased() == "true")
+                    case .integer:
+                        settings[entry.key] = .int(Int(entry.value) ?? 0)
+                    case .string:
+                        settings[entry.key] = .string(entry.value)
+                    }
+                }
+            } else {
+                // No category prefix - add to settings
+                switch entry.valueType {
+                case .boolean:
+                    settings[entry.key] = .bool(entry.value.lowercased() == "true")
+                case .integer:
+                    settings[entry.key] = .int(Int(entry.value) ?? 0)
+                case .string:
+                    settings[entry.key] = .string(entry.value)
+                }
+            }
+        }
+
+        return RemoteConfig.Get.Response(
+            featureFlags: featureFlags,
+            settings: settings
+        )
+    }
+
+    /// Validates that the value can be parsed as the specified type.
+    private func validateValueMatchesType(_ value: String, type: ConfigValueType) throws {
+        switch type {
+        case .boolean:
+            let lowercased = value.lowercased()
+            if lowercased != "true" && lowercased != "false" {
+                throw Abort(.badRequest, reason: "Value '\(value)' is not a valid boolean (use 'true' or 'false')")
+            }
+        case .integer:
+            if Int(value) == nil {
+                throw Abort(.badRequest, reason: "Value '\(value)' is not a valid integer")
+            }
+        case .string:
+            // Any string is valid
+            break
+        }
+    }
+
+    /// Invalidates the remote config cache.
+    private func invalidateCache(_ req: Request) async throws {
+        try await req.services.cache.delete(Self.cacheKey)
+        req.logger.debug("Remote config cache invalidated")
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/Controller/RemoteConfigController.swift
+++ b/Sources/App/Modules/RemoteConfig/Controller/RemoteConfigController.swift
@@ -76,7 +76,16 @@ struct RemoteConfigController {
             valueType: valueType
         )
 
-        try await repository.create(model)
+        do {
+            try await repository.create(model)
+        } catch {
+            // Handle database unique constraint violations as 409 Conflict
+            let errorDescription = String(describing: error).lowercased()
+            if errorDescription.contains("unique") || errorDescription.contains("duplicate") {
+                throw Abort(.conflict, reason: "Configuration key '\(createRequest.key)' already exists")
+            }
+            throw error
+        }
 
         // Invalidate cache
         try await invalidateCache(req)
@@ -106,8 +115,10 @@ struct RemoteConfigController {
 
         // Determine value type (use existing if not provided)
         let valueType: ConfigValueType
-        if let newTypeString = updateRequest.valueType,
-           let newType = ConfigValueType(rawValue: newTypeString) {
+        if let newTypeString = updateRequest.valueType {
+            guard let newType = ConfigValueType(rawValue: newTypeString) else {
+                throw Abort(.badRequest, reason: "Invalid value type: \(newTypeString)")
+            }
             valueType = newType
         } else {
             valueType = model.valueType
@@ -174,6 +185,16 @@ struct RemoteConfigController {
                 case "featureFlags":
                     if entry.valueType == .boolean {
                         featureFlags[name] = entry.value.lowercased() == "true"
+                    } else {
+                        // Non-boolean featureFlags fall through to settings to avoid data loss
+                        switch entry.valueType {
+                        case .boolean:
+                            settings[name] = .bool(entry.value.lowercased() == "true")
+                        case .integer:
+                            settings[name] = .int(Int(entry.value) ?? 0)
+                        case .string:
+                            settings[name] = .string(entry.value)
+                        }
                     }
                 case "settings":
                     switch entry.valueType {

--- a/Sources/App/Modules/RemoteConfig/Database/Migrations/RemoteConfigMigrations.swift
+++ b/Sources/App/Modules/RemoteConfig/Database/Migrations/RemoteConfigMigrations.swift
@@ -1,0 +1,44 @@
+import Fluent
+import Vapor
+
+enum RemoteConfigMigrations {
+
+    struct v1: AsyncMigration {
+
+        func prepare(on db: Database) async throws {
+            try await db.schema(RemoteConfigModel.schema)
+                .id()
+                .field(RemoteConfigModel.FieldKeys.v1.key, .string, .required)
+                .field(RemoteConfigModel.FieldKeys.v1.value, .string, .required)
+                .field(RemoteConfigModel.FieldKeys.v1.valueType, .string, .required)
+                .field(RemoteConfigModel.FieldKeys.v1.createdAt, .datetime)
+                .field(RemoteConfigModel.FieldKeys.v1.updatedAt, .datetime)
+                .unique(on: RemoteConfigModel.FieldKeys.v1.key)
+                .create()
+        }
+
+        func revert(on db: Database) async throws {
+            try await db.schema(RemoteConfigModel.schema).delete()
+        }
+    }
+
+    /// Seeds default configuration values for development.
+    struct seed: AsyncMigration {
+
+        func prepare(on db: Database) async throws {
+            // Feature flags
+            let enablePaywall = RemoteConfigModel.create(key: "featureFlags.enablePaywall", boolValue: true)
+            try await enablePaywall.create(on: db)
+
+            // Settings
+            let maxRetries = RemoteConfigModel.create(key: "settings.maxRetries", intValue: 3)
+            try await maxRetries.create(on: db)
+        }
+
+        func revert(on db: Database) async throws {
+            try await RemoteConfigModel.query(on: db)
+                .filter(\.$key ~~ ["featureFlags.enablePaywall", "settings.maxRetries"])
+                .delete()
+        }
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/Database/Models/RemoteConfigModel.swift
+++ b/Sources/App/Modules/RemoteConfig/Database/Models/RemoteConfigModel.swift
@@ -1,0 +1,95 @@
+import Fluent
+import Vapor
+
+/// Represents a configuration value for remote configuration.
+///
+/// Stores typed configuration values (boolean, integer, string) that can be
+/// fetched by mobile apps to control behavior remotely without app updates.
+final class RemoteConfigModel: @unchecked Sendable, DatabaseModelInterface {
+    typealias Module = RemoteConfigModule
+    static var schema: String { "remote_config" }
+
+    @ID()
+    var id: UUID?
+
+    @Field(key: FieldKeys.v1.key)
+    var key: String
+
+    @Field(key: FieldKeys.v1.value)
+    var value: String
+
+    @Field(key: FieldKeys.v1.valueType)
+    var valueType: ConfigValueType
+
+    @Timestamp(key: FieldKeys.v1.createdAt, on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: FieldKeys.v1.updatedAt, on: .update)
+    var updatedAt: Date?
+
+    init() { }
+
+    init(
+        id: UUID? = nil,
+        key: String,
+        value: String,
+        valueType: ConfigValueType
+    ) {
+        self.id = id
+        self.key = key
+        self.value = value
+        self.valueType = valueType
+    }
+}
+
+// MARK: - Value Type Enum
+
+/// Supported configuration value types.
+enum ConfigValueType: String, Codable, CaseIterable {
+    case boolean
+    case integer
+    case string
+}
+
+// MARK: - Field Keys
+
+extension RemoteConfigModel {
+    struct FieldKeys {
+        struct v1 {
+            static var key: FieldKey { "key" }
+            static var value: FieldKey { "value" }
+            static var valueType: FieldKey { "value_type" }
+            static var createdAt: FieldKey { "created_at" }
+            static var updatedAt: FieldKey { "updated_at" }
+        }
+    }
+}
+
+// MARK: - Convenience Methods
+
+extension RemoteConfigModel {
+    /// Returns the typed value based on valueType.
+    var typedValue: Any {
+        switch valueType {
+        case .boolean:
+            return value.lowercased() == "true"
+        case .integer:
+            return Int(value) ?? 0
+        case .string:
+            return value
+        }
+    }
+
+    /// Creates a RemoteConfigModel with proper type inference.
+    static func create(key: String, boolValue: Bool) -> RemoteConfigModel {
+        RemoteConfigModel(key: key, value: String(boolValue), valueType: .boolean)
+    }
+
+    static func create(key: String, intValue: Int) -> RemoteConfigModel {
+        RemoteConfigModel(key: key, value: String(intValue), valueType: .integer)
+    }
+
+    static func create(key: String, stringValue: String) -> RemoteConfigModel {
+        RemoteConfigModel(key: key, value: stringValue, valueType: .string)
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/Models/RemoteConfig+Model.swift
+++ b/Sources/App/Modules/RemoteConfig/Models/RemoteConfig+Model.swift
@@ -61,6 +61,8 @@ enum RemoteConfig {
 
             static func validations(_ validations: inout Validations) {
                 validations.add("value", as: String.self, is: !.empty)
+                // Validate valueType if provided (optional field)
+                validations.add("valueType", as: String?.self, is: .nil || .in("boolean", "integer", "string"), required: false)
             }
         }
 

--- a/Sources/App/Modules/RemoteConfig/Models/RemoteConfig+Model.swift
+++ b/Sources/App/Modules/RemoteConfig/Models/RemoteConfig+Model.swift
@@ -1,0 +1,124 @@
+import Vapor
+
+/// Remote configuration request/response models organized by operation.
+enum RemoteConfig {
+
+    // MARK: - Public Endpoint
+
+    enum Get {
+        /// Response for the public config endpoint.
+        /// Groups configuration values by category (featureFlags, settings).
+        struct Response: Content {
+            let featureFlags: [String: Bool]
+            let settings: [String: AnyCodableValue]
+        }
+    }
+
+    // MARK: - Admin Endpoints
+
+    enum List {
+        /// Response for listing all configuration entries with metadata.
+        struct Response: Content {
+            let entries: [Entry]
+        }
+
+        struct Entry: Content {
+            let id: UUID
+            let key: String
+            let value: String
+            let valueType: String
+            let createdAt: Date?
+            let updatedAt: Date?
+        }
+    }
+
+    enum Create {
+        struct Request: Content, Validatable {
+            let key: String
+            let value: String
+            let valueType: String
+
+            static func validations(_ validations: inout Validations) {
+                validations.add("key", as: String.self, is: !.empty)
+                validations.add("value", as: String.self, is: !.empty)
+                validations.add("valueType", as: String.self, is: .in("boolean", "integer", "string"))
+            }
+        }
+
+        struct Response: Content {
+            let id: UUID
+            let key: String
+            let value: String
+            let valueType: String
+            let message: String
+        }
+    }
+
+    enum Update {
+        struct Request: Content, Validatable {
+            let value: String
+            let valueType: String?
+
+            static func validations(_ validations: inout Validations) {
+                validations.add("value", as: String.self, is: !.empty)
+            }
+        }
+
+        struct Response: Content {
+            let id: UUID
+            let key: String
+            let value: String
+            let valueType: String
+            let message: String
+        }
+    }
+
+    enum Delete {
+        struct Response: Content {
+            let key: String
+            let message: String
+        }
+    }
+}
+
+// MARK: - Type-Erased Codable Value
+
+/// A type-erased codable value that can hold any JSON-compatible value.
+/// Used for settings which can be integers or strings.
+enum AnyCodableValue: Codable, Equatable {
+    case int(Int)
+    case string(String)
+    case bool(Bool)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let intValue = try? container.decode(Int.self) {
+            self = .int(intValue)
+        } else if let boolValue = try? container.decode(Bool.self) {
+            self = .bool(boolValue)
+        } else if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
+        } else {
+            throw DecodingError.typeMismatch(
+                AnyCodableValue.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expected Int, Bool, or String"
+                )
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .int(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        }
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/RemoteConfigModule.swift
+++ b/Sources/App/Modules/RemoteConfig/RemoteConfigModule.swift
@@ -1,0 +1,17 @@
+import Vapor
+
+struct RemoteConfigModule: ModuleInterface {
+
+    let router = RemoteConfigRouter()
+
+    func boot(_ app: Application) throws {
+        app.migrations.add(RemoteConfigMigrations.v1())
+
+        // Only add seed data in development environment
+        if app.environment == .development {
+            app.migrations.add(RemoteConfigMigrations.seed())
+        }
+
+        try router.boot(routes: app.routes)
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/RemoteConfigRouter.swift
+++ b/Sources/App/Modules/RemoteConfig/RemoteConfigRouter.swift
@@ -1,0 +1,64 @@
+import Vapor
+import VaporToOpenAPI
+
+struct RemoteConfigRouter: RouteCollection {
+    let controller = RemoteConfigController()
+
+    func boot(routes: RoutesBuilder) throws {
+        let api = routes
+            .grouped("api")
+            .grouped("v1")
+            .grouped("config")
+            .groupedOpenAPI(tags: .init(name: "Remote Config", description: "Remote configuration management"))
+
+        // Public endpoint - no authentication required
+        api
+            .get(use: controller.getConfig)
+            .openAPI(
+                description: "Fetch all remote configuration values. Returns feature flags and settings grouped by category.",
+                response: .type(RemoteConfig.Get.Response.self)
+            )
+
+        // Admin-only endpoints - require authentication and admin role
+        let adminAPI = api
+            .grouped(UserAccountModel.guard())
+            .grouped(EnsureAdminUserMiddleware())
+
+        adminAPI
+            .get("admin", use: controller.listAllConfig)
+            .openAPI(
+                description: "List all configuration entries with metadata. Admin only.",
+                response: .type(RemoteConfig.List.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+
+        adminAPI
+            .post(use: controller.createConfig)
+            .openAPI(
+                description: "Create a new configuration entry. Admin only.",
+                body: .type(RemoteConfig.Create.Request.self),
+                response: .type(RemoteConfig.Create.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+            .response(statusCode: .conflict, description: "Configuration key already exists")
+
+        adminAPI
+            .patch(":key", use: controller.updateConfig)
+            .openAPI(
+                description: "Update an existing configuration entry. Admin only.",
+                body: .type(RemoteConfig.Update.Request.self),
+                response: .type(RemoteConfig.Update.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+            .response(statusCode: .notFound, description: "Configuration key not found")
+
+        adminAPI
+            .delete(":key", use: controller.deleteConfig)
+            .openAPI(
+                description: "Delete a configuration entry. Admin only.",
+                response: .type(RemoteConfig.Delete.Response.self),
+                auth: .bearer(id: "bearerAuth")
+            )
+            .response(statusCode: .notFound, description: "Configuration key not found")
+    }
+}

--- a/Sources/App/Modules/RemoteConfig/Repositories/RemoteConfigRepository.swift
+++ b/Sources/App/Modules/RemoteConfig/Repositories/RemoteConfigRepository.swift
@@ -1,0 +1,47 @@
+import Fluent
+import Vapor
+
+protocol RemoteConfigRepository: Repository {
+    func findAll() async throws -> [RemoteConfigModel]
+    func find(key: String) async throws -> RemoteConfigModel?
+    func create(_ model: RemoteConfigModel) async throws
+    func update(_ model: RemoteConfigModel) async throws
+    func delete(_ model: RemoteConfigModel) async throws
+}
+
+struct DatabaseRemoteConfigRepository: RemoteConfigRepository, DatabaseRepository {
+    typealias Model = RemoteConfigModel
+    let database: Database
+
+    func findAll() async throws -> [RemoteConfigModel] {
+        try await RemoteConfigModel.query(on: database)
+            .sort(\.$key)
+            .all()
+    }
+
+    func find(key: String) async throws -> RemoteConfigModel? {
+        try await RemoteConfigModel.query(on: database)
+            .filter(\.$key == key)
+            .first()
+    }
+
+    func create(_ model: RemoteConfigModel) async throws {
+        try await model.create(on: database)
+    }
+
+    func update(_ model: RemoteConfigModel) async throws {
+        try await model.update(on: database)
+    }
+
+    func delete(_ model: RemoteConfigModel) async throws {
+        try await model.delete(on: database)
+    }
+}
+
+// MARK: - Application.Repositories Extension
+
+extension Application.Repositories {
+    var remoteConfig: any RemoteConfigRepository {
+        application.remoteConfigRepository
+    }
+}

--- a/Tests/AppTests/Framework/IsolatedTestWorld.swift
+++ b/Tests/AppTests/Framework/IsolatedTestWorld.swift
@@ -81,6 +81,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
     private let emailTokenRepository: TestEmailTokenRepository
     private let passwordTokenRepository: TestPasswordTokenRepository
     private let generatedRuleRepository: TestGeneratedRuleRepository
+    private let remoteConfigRepository: TestRemoteConfigRepository
     
     // MARK: - Mock Services
     private let fakeLLMService: FakeLLMService
@@ -107,6 +108,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
         self.emailTokenRepository = TestEmailTokenRepository()
         self.passwordTokenRepository = TestPasswordTokenRepository()
         self.generatedRuleRepository = TestGeneratedRuleRepository()
+        self.remoteConfigRepository = TestRemoteConfigRepository()
         
         // Create fresh service instances
         self.fakeLLMService = FakeLLMService(app: app)
@@ -148,6 +150,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
         app.emailTokenRepository = self.emailTokenRepository
         app.passwordTokenRepository = self.passwordTokenRepository
         app.generatedRuleRepository = self.generatedRuleRepository
+        app.remoteConfigRepository = self.remoteConfigRepository
 
         // Assign mock services directly to Application storage
         app.emailService = FakeEmailProvider()
@@ -217,7 +220,12 @@ final class IsolatedTestWorld: @unchecked Sendable {
     var generatedRules: TestGeneratedRuleRepository {
         generatedRuleRepository
     }
-    
+
+    /// Access to the isolated remote config repository.
+    var remoteConfigs: TestRemoteConfigRepository {
+        remoteConfigRepository
+    }
+
     // MARK: - Public Access to Mock Services
     
     /// Access to the isolated LLM service for configuring AI responses.
@@ -254,6 +262,7 @@ final class IsolatedTestWorld: @unchecked Sendable {
         await emailTokenRepository.reset()
         await passwordTokenRepository.reset()
         await generatedRuleRepository.reset()
+        await remoteConfigRepository.reset()
         
         // Reset services
         fakeLLMService.reset()

--- a/Tests/AppTests/Framework/IsolatedTestWorld.swift
+++ b/Tests/AppTests/Framework/IsolatedTestWorld.swift
@@ -15,19 +15,19 @@ final class InMemoryTestCacheService: CacheService, @unchecked Sendable {
     }
     
     func set<T>(_ key: String, value: T, ttl: TimeInterval?) async throws where T: Codable {
-        queue.async(flags: .barrier) { [weak self] in
+        queue.sync(flags: .barrier) { [weak self] in
             self?.storage[key] = value
         }
     }
-    
+
     func delete(_ key: String) async throws {
-        queue.async(flags: .barrier) { [weak self] in
+        _ = queue.sync(flags: .barrier) { [weak self] in
             self?.storage.removeValue(forKey: key)
         }
     }
-    
+
     func flush() async throws {
-        queue.async(flags: .barrier) { [weak self] in
+        queue.sync(flags: .barrier) { [weak self] in
             self?.storage.removeAll()
         }
     }

--- a/Tests/AppTests/Framework/Mocks/Repositories/TestRemoteConfigRepository.swift
+++ b/Tests/AppTests/Framework/Mocks/Repositories/TestRemoteConfigRepository.swift
@@ -1,0 +1,67 @@
+@testable import App
+import Vapor
+import Fluent
+
+actor TestRemoteConfigRepository: RemoteConfigRepository, TestRepository {
+    var configs: [RemoteConfigModel]
+
+    /// Alias for consistent test interface
+    var entities: [RemoteConfigModel] {
+        get { configs }
+        set { configs = newValue }
+    }
+
+    init(configs: [RemoteConfigModel] = []) {
+        self.configs = configs
+    }
+
+    typealias Model = RemoteConfigModel
+
+    func findAll() async throws -> [RemoteConfigModel] {
+        configs.sorted { $0.key < $1.key }
+    }
+
+    func find(key: String) async throws -> RemoteConfigModel? {
+        configs.first(where: { $0.key == key })
+    }
+
+    func create(_ model: RemoteConfigModel) async throws {
+        // Simulate unique key constraint like a real database
+        if configs.contains(where: { $0.key == model.key }) {
+            throw Abort(.conflict, reason: "UNIQUE constraint failed: remote_config.key")
+        }
+        model.id = model.id ?? UUID()
+        configs.append(model)
+    }
+
+    func update(_ model: RemoteConfigModel) async throws {
+        guard let id = model.id,
+              let index = configs.firstIndex(where: { $0.id == id }) else {
+            throw Abort(.notFound)
+        }
+        configs[index] = model
+    }
+
+    func delete(_ model: RemoteConfigModel) async throws {
+        guard let id = model.id else {
+            throw Abort(.notFound)
+        }
+        configs.removeAll(where: { $0.id == id })
+    }
+
+    func delete(id: UUID) async throws {
+        configs.removeAll(where: { $0.id == id })
+    }
+
+    func count() async throws -> Int {
+        configs.count
+    }
+
+    func reset() async {
+        configs.removeAll()
+    }
+
+    nonisolated func `for`(_ req: Request) -> TestRemoteConfigRepository {
+        return self
+    }
+}

--- a/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigAdminTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigAdminTests.swift
@@ -286,4 +286,77 @@ struct RemoteConfigAdminTests {
             }
         })
     }
+
+    // MARK: - Value Type Validation Tests
+
+    @Test("Create fails with invalid valueType", .tags(.p1Core, .integration))
+    func createFailsWithInvalidValueType() async throws {
+        await testWorld.resetAll()
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        let payload = try TokenPayload(with: user)
+        let accessToken = try app.jwt.signers.sign(payload)
+
+        // Use raw JSON to send invalid valueType that bypasses Codable validation
+        try await app.test(.POST, configPath, beforeRequest: { req in
+            req.headers.add(name: "Authorization", value: "Bearer \(accessToken)")
+            req.headers.contentType = .json
+            req.body = ByteBuffer(string: """
+                {"key": "test.key", "value": "123", "valueType": "invalid"}
+            """)
+        }, afterResponse: { res in
+            #expect(res.status == .badRequest)
+        })
+    }
+
+    @Test("Update fails with invalid valueType", .tags(.p1Core, .integration))
+    func updateFailsWithInvalidValueType() async throws {
+        await testWorld.resetAll()
+
+        let config = RemoteConfigModel.create(key: "settings.testKey", intValue: 42)
+        try await app.repositories.remoteConfig.create(config)
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        let payload = try TokenPayload(with: user)
+        let accessToken = try app.jwt.signers.sign(payload)
+
+        // Use raw JSON to send invalid valueType that bypasses Codable validation
+        try await app.test(.PATCH, "\(configPath)/settings.testKey", beforeRequest: { req in
+            req.headers.add(name: "Authorization", value: "Bearer \(accessToken)")
+            req.headers.contentType = .json
+            req.body = ByteBuffer(string: """
+                {"value": "100", "valueType": "invalid"}
+            """)
+        }, afterResponse: { res in
+            #expect(res.status == .badRequest)
+        })
+    }
+
+    @Test("Update without valueType preserves existing type", .tags(.p1Core, .integration))
+    func updateWithoutValueTypePreservesExistingType() async throws {
+        await testWorld.resetAll()
+
+        let config = RemoteConfigModel.create(key: "settings.preserveType", intValue: 42)
+        try await app.repositories.remoteConfig.create(config)
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        let updateRequest = RemoteConfig.Update.Request(
+            value: "100",
+            valueType: nil
+        )
+
+        try await app.test(.PATCH, "\(configPath)/settings.preserveType", user: user, content: updateRequest, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.Update.Response.self, res) { response in
+                #expect(response.value == "100")
+                #expect(response.valueType == "integer") // Type should be preserved
+            }
+        })
+    }
 }

--- a/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigAdminTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigAdminTests.swift
@@ -1,0 +1,289 @@
+@testable import App
+import Fluent
+import VaporTesting
+import Testing
+
+@Suite(.serialized)
+struct RemoteConfigAdminTests {
+    let app: Application
+    let testWorld: IsolatedTestWorld
+    let configPath = "api/v1/config"
+
+    init() async throws {
+        testWorld = try await IsolatedTestWorld()
+        app = testWorld.app
+    }
+
+    // MARK: - Create Config Tests
+
+    @Test("Admin can create config entry", .tags(.p0Critical, .integration))
+    func adminCreateConfig() async throws {
+        await testWorld.resetAll()
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "featureFlags.newFeature",
+            value: "true",
+            valueType: "boolean"
+        )
+
+        try await app.test(.POST, configPath, user: user, content: createRequest, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.Create.Response.self, res) { response in
+                #expect(response.key == "featureFlags.newFeature")
+                #expect(response.value == "true")
+                #expect(response.valueType == "boolean")
+            }
+        })
+
+        // Verify entry was persisted
+        let count = try await app.repositories.remoteConfig.count()
+        #expect(count == 1)
+    }
+
+    @Test("Admin can create integer config entry", .tags(.p1Core, .integration))
+    func adminCreateIntegerConfig() async throws {
+        await testWorld.resetAll()
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "settings.maxItems",
+            value: "100",
+            valueType: "integer"
+        )
+
+        try await app.test(.POST, configPath, user: user, content: createRequest, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.Create.Response.self, res) { response in
+                #expect(response.value == "100")
+                #expect(response.valueType == "integer")
+            }
+        })
+    }
+
+    @Test("Create fails with duplicate key", .tags(.p1Core, .integration))
+    func createFailsWithDuplicateKey() async throws {
+        await testWorld.resetAll()
+
+        let existing = RemoteConfigModel.create(key: "featureFlags.existing", boolValue: true)
+        try await app.repositories.remoteConfig.create(existing)
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "featureFlags.existing",
+            value: "false",
+            valueType: "boolean"
+        )
+
+        try await app.test(.POST, configPath, user: user, content: createRequest, afterResponse: { res in
+            #expect(res.status == .conflict)
+        })
+    }
+
+    // MARK: - Update Config Tests
+
+    @Test("Admin can update config entry", .tags(.p0Critical, .integration))
+    func adminUpdateConfig() async throws {
+        await testWorld.resetAll()
+
+        let config = RemoteConfigModel.create(key: "featureFlags.updateMe", boolValue: false)
+        try await app.repositories.remoteConfig.create(config)
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        let updateRequest = RemoteConfig.Update.Request(
+            value: "true",
+            valueType: nil
+        )
+
+        try await app.test(.PATCH, "\(configPath)/featureFlags.updateMe", user: user, content: updateRequest, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.Update.Response.self, res) { response in
+                #expect(response.key == "featureFlags.updateMe")
+                #expect(response.value == "true")
+            }
+        })
+    }
+
+    @Test("Update fails for non-existent key", .tags(.p1Core, .integration))
+    func updateFailsForNonExistentKey() async throws {
+        await testWorld.resetAll()
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        let updateRequest = RemoteConfig.Update.Request(
+            value: "true",
+            valueType: nil
+        )
+
+        try await app.test(.PATCH, "\(configPath)/nonexistent.key", user: user, content: updateRequest, afterResponse: { res in
+            #expect(res.status == .notFound)
+        })
+    }
+
+    // MARK: - Delete Config Tests
+
+    @Test("Admin can delete config entry", .tags(.p0Critical, .integration))
+    func adminDeleteConfig() async throws {
+        await testWorld.resetAll()
+
+        let config = RemoteConfigModel.create(key: "featureFlags.deleteMe", boolValue: true)
+        try await app.repositories.remoteConfig.create(config)
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        try await app.test(.DELETE, "\(configPath)/featureFlags.deleteMe", user: user, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.Delete.Response.self, res) { response in
+                #expect(response.key == "featureFlags.deleteMe")
+            }
+        })
+
+        // Verify entry was deleted
+        let count = try await app.repositories.remoteConfig.count()
+        #expect(count == 0)
+    }
+
+    @Test("Delete fails for non-existent key", .tags(.p1Core, .integration))
+    func deleteFailsForNonExistentKey() async throws {
+        await testWorld.resetAll()
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        try await app.test(.DELETE, "\(configPath)/nonexistent.key", user: user, afterResponse: { res in
+            #expect(res.status == .notFound)
+        })
+    }
+
+    // MARK: - Authentication Tests
+
+    @Test("Non-authenticated user gets 401 on admin endpoints", .tags(.p0Critical, .integration))
+    func nonAuthenticatedUserGetsForbidden() async throws {
+        await testWorld.resetAll()
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "featureFlags.test",
+            value: "true",
+            valueType: "boolean"
+        )
+
+        // POST without auth
+        try await app.test(.POST, configPath, content: createRequest, afterResponse: { res in
+            #expect(res.status == .unauthorized)
+        })
+
+        // PATCH without auth
+        try await app.test(.PATCH, "\(configPath)/somekey", content: RemoteConfig.Update.Request(value: "test", valueType: nil), afterResponse: { res in
+            #expect(res.status == .unauthorized)
+        })
+
+        // DELETE without auth
+        try await app.test(.DELETE, "\(configPath)/somekey", afterResponse: { res in
+            #expect(res.status == .unauthorized)
+        })
+
+        // Admin list without auth
+        try await app.test(.GET, "\(configPath)/admin", afterResponse: { res in
+            #expect(res.status == .unauthorized)
+        })
+    }
+
+    @Test("Authenticated non-admin user gets 401 on admin endpoints", .tags(.p0Critical, .integration))
+    func nonAdminUserGetsForbidden() async throws {
+        await testWorld.resetAll()
+
+        // Create regular (non-admin) user
+        let user = try UserAccountModel.mock(app: app, isAdmin: false)
+        try await app.repositories.users.create(user)
+
+        let createRequest = RemoteConfig.Create.Request(
+            key: "featureFlags.test",
+            value: "true",
+            valueType: "boolean"
+        )
+
+        // POST as non-admin
+        try await app.test(.POST, configPath, user: user, content: createRequest, afterResponse: { res in
+            #expect(res.status == .unauthorized)
+        })
+
+        // PATCH as non-admin
+        try await app.test(.PATCH, "\(configPath)/somekey", user: user, content: RemoteConfig.Update.Request(value: "test", valueType: nil), afterResponse: { res in
+            #expect(res.status == .unauthorized)
+        })
+
+        // DELETE as non-admin
+        try await app.test(.DELETE, "\(configPath)/somekey", user: user, afterResponse: { res in
+            #expect(res.status == .unauthorized)
+        })
+    }
+
+    // MARK: - Cache Invalidation Tests
+
+    @Test("Cache invalidation on write operations", .tags(.p1Core, .integration))
+    func cacheInvalidationOnWrite() async throws {
+        await testWorld.resetAll()
+
+        let config = RemoteConfigModel.create(key: "featureFlags.cacheInvalidate", boolValue: true)
+        try await app.repositories.remoteConfig.create(config)
+
+        // First GET to populate cache
+        try await app.test(.GET, configPath, afterResponse: { res in
+            #expect(res.status == .ok)
+        })
+
+        // Verify cache exists
+        let cacheKey = "remote_config_all"
+        var cached = try await app.cacheService.exists(cacheKey)
+        #expect(cached == true)
+
+        // Create admin user and update config
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        // Update should invalidate cache
+        try await app.test(.PATCH, "\(configPath)/featureFlags.cacheInvalidate", user: user, content: RemoteConfig.Update.Request(value: "false", valueType: nil), afterResponse: { res in
+            #expect(res.status == .ok)
+        })
+
+        // Verify cache was invalidated
+        cached = try await app.cacheService.exists(cacheKey)
+        #expect(cached == false)
+    }
+
+    // MARK: - List Admin Config Tests
+
+    @Test("Admin can list all config entries with metadata", .tags(.p1Core, .integration))
+    func adminListConfig() async throws {
+        await testWorld.resetAll()
+
+        let config1 = RemoteConfigModel.create(key: "featureFlags.flag1", boolValue: true)
+        let config2 = RemoteConfigModel.create(key: "settings.setting1", intValue: 42)
+        try await app.repositories.remoteConfig.create(config1)
+        try await app.repositories.remoteConfig.create(config2)
+
+        let user = try UserAccountModel.mock(app: app, isAdmin: true)
+        try await app.repositories.users.create(user)
+
+        try await app.test(.GET, "\(configPath)/admin", user: user, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.List.Response.self, res) { response in
+                #expect(response.entries.count == 2)
+                // Entries should include metadata (id, valueType, timestamps)
+                let flag = response.entries.first { $0.key == "featureFlags.flag1" }
+                #expect(flag?.valueType == "boolean")
+                #expect(flag?.value == "true")
+            }
+        })
+    }
+}

--- a/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigGetTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/RemoteConfigTests/RemoteConfigGetTests.swift
@@ -1,0 +1,99 @@
+@testable import App
+import Fluent
+import VaporTesting
+import Testing
+
+@Suite(.serialized)
+struct RemoteConfigGetTests {
+    let app: Application
+    let testWorld: IsolatedTestWorld
+    let configPath = "api/v1/config"
+
+    init() async throws {
+        testWorld = try await IsolatedTestWorld()
+        app = testWorld.app
+    }
+
+    @Test("Public endpoint returns config without authentication", .tags(.p0Critical, .integration))
+    func getConfigPublicEndpoint() async throws {
+        await testWorld.resetAll()
+
+        // Create some config entries
+        let enablePaywall = RemoteConfigModel.create(key: "featureFlags.enablePaywall", boolValue: true)
+        let maxRetries = RemoteConfigModel.create(key: "settings.maxRetries", intValue: 3)
+
+        try await app.repositories.remoteConfig.create(enablePaywall)
+        try await app.repositories.remoteConfig.create(maxRetries)
+
+        // No authentication header - should still work
+        try await app.test(.GET, configPath, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.Get.Response.self, res) { config in
+                #expect(config.featureFlags["enablePaywall"] == true)
+                #expect(config.settings["maxRetries"] == .int(3))
+            }
+        })
+    }
+
+    @Test("Config response structure matches expected format", .tags(.p0Critical, .integration))
+    func configResponseStructure() async throws {
+        await testWorld.resetAll()
+
+        // Create varied config entries
+        let featureFlag = RemoteConfigModel.create(key: "featureFlags.darkMode", boolValue: false)
+        let intSetting = RemoteConfigModel.create(key: "settings.timeout", intValue: 30)
+        let stringSetting = RemoteConfigModel.create(key: "settings.apiUrl", stringValue: "https://api.example.com")
+
+        try await app.repositories.remoteConfig.create(featureFlag)
+        try await app.repositories.remoteConfig.create(intSetting)
+        try await app.repositories.remoteConfig.create(stringSetting)
+
+        try await app.test(.GET, configPath, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.Get.Response.self, res) { config in
+                // Feature flags should be grouped correctly
+                #expect(config.featureFlags["darkMode"] == false)
+
+                // Settings should be grouped correctly with proper types
+                #expect(config.settings["timeout"] == .int(30))
+                #expect(config.settings["apiUrl"] == .string("https://api.example.com"))
+            }
+        })
+    }
+
+    @Test("Returns empty config when no entries exist", .tags(.p1Core, .integration))
+    func emptyConfigResponse() async throws {
+        await testWorld.resetAll()
+
+        try await app.test(.GET, configPath, afterResponse: { res in
+            #expect(res.status == .ok)
+            expectContent(RemoteConfig.Get.Response.self, res) { config in
+                #expect(config.featureFlags.isEmpty)
+                #expect(config.settings.isEmpty)
+            }
+        })
+    }
+
+    @Test("Config values are cached in Redis", .tags(.p1Core, .integration))
+    func configCaching() async throws {
+        await testWorld.resetAll()
+
+        let config = RemoteConfigModel.create(key: "featureFlags.cacheTest", boolValue: true)
+        try await app.repositories.remoteConfig.create(config)
+
+        // First request - should be cache miss
+        try await app.test(.GET, configPath, afterResponse: { res in
+            #expect(res.status == .ok)
+        })
+
+        // Verify cache was populated
+        let cacheKey = "remote_config_all"
+        let cached = try await app.cacheService.exists(cacheKey)
+        #expect(cached == true)
+
+        // Second request should use cache (we verify by checking cache still exists)
+        try await app.test(.GET, configPath, afterResponse: { res in
+            #expect(res.status == .ok)
+        })
+    }
+}

--- a/docs/CONDITIONAL_DOCS.md
+++ b/docs/CONDITIONAL_DOCS.md
@@ -19,3 +19,11 @@ This guide helps you find relevant documentation based on what you're working on
     - When troubleshooting mobile app integration issues
     - When planning breaking API changes
     - When writing integration tests for API endpoints
+
+- docs/features/remote-config.md
+  - Conditions:
+    - When implementing feature flags or remote configuration
+    - When adding public endpoints that don't require authentication
+    - When adding admin-only endpoints to an existing module
+    - When implementing Redis caching with write-through invalidation
+    - When modifying the RemoteConfig module

--- a/docs/features/remote-config.md
+++ b/docs/features/remote-config.md
@@ -1,0 +1,94 @@
+# Remote Configuration Endpoint
+
+**Date:** 2026-01-22
+**Related Files:** `Sources/App/Modules/RemoteConfig/`
+
+## Overview
+
+Remote configuration allows mobile apps to fetch feature flags and settings from the backend, enabling app behavior to be controlled remotely without requiring app updates. This module provides a public endpoint for apps to fetch config values and admin endpoints for managing configuration entries.
+
+## What Was Built
+
+- **Public GET endpoint** (`/api/v1/config`) - Returns grouped configuration (feature flags + settings)
+- **Admin CRUD endpoints** - Create, read, update, delete config entries (requires admin authentication)
+- **Redis caching** - 5-minute TTL with automatic invalidation on writes
+- **Typed values** - Support for boolean, integer, and string configuration values
+
+## Technical Implementation
+
+### Key Files
+
+- `RemoteConfigController.swift`: Main controller with public and admin endpoint handlers
+- `RemoteConfigRouter.swift`: Route registration with authentication middleware
+- `RemoteConfigModel.swift`: Database model with typed value support
+- `RemoteConfig+Model.swift`: Request/response DTOs and `AnyCodableValue` type
+- `RemoteConfigRepository.swift`: Repository pattern implementation
+
+### Key Patterns
+
+- **Public + Admin Endpoint Separation**: The router registers the public GET endpoint without authentication, then creates a grouped route with `UserAccountModel.guard()` and `EnsureAdminUserMiddleware()` for admin-only operations.
+
+- **Redis Caching with Write-Through Invalidation**: The public endpoint checks Redis cache first. On cache miss, it fetches from database and caches with 5-minute TTL. All write operations (POST, PATCH, DELETE) invalidate the cache.
+
+- **Typed Value Storage**: Values are stored as strings in the database with a `valueType` enum (boolean/integer/string). The controller transforms these to proper JSON types in the response.
+
+- **Key Naming Convention**: Config keys use dot notation for categorization: `featureFlags.enablePaywall` or `settings.maxRetries`. The controller parses these to group values in the response.
+
+### Code Examples
+
+**Adding a new config entry (admin):**
+```bash
+curl -X POST /api/v1/config \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key": "featureFlags.newFeature", "value": "true", "valueType": "boolean"}'
+```
+
+**Fetching config (public):**
+```bash
+curl /api/v1/config
+# Returns:
+# {
+#   "featureFlags": {"enablePaywall": true},
+#   "settings": {"maxRetries": 3}
+# }
+```
+
+**Creating config entries in code:**
+```swift
+// Boolean feature flag
+let flag = RemoteConfigModel.create(key: "featureFlags.darkMode", boolValue: true)
+
+// Integer setting
+let setting = RemoteConfigModel.create(key: "settings.timeout", intValue: 30)
+
+// String setting
+let apiUrl = RemoteConfigModel.create(key: "settings.apiUrl", stringValue: "https://api.example.com")
+```
+
+## How to Use
+
+1. **For mobile apps**: Call `GET /api/v1/config` (no authentication required) to fetch all feature flags and settings as a single JSON response.
+
+2. **For admin management**: Use the admin endpoints with a valid admin JWT token:
+   - `POST /api/v1/config` - Create a new config entry
+   - `PATCH /api/v1/config/:key` - Update an existing entry
+   - `DELETE /api/v1/config/:key` - Delete an entry
+   - `GET /api/v1/config/admin` - List all entries with metadata
+
+3. **Key naming**: Use `featureFlags.` prefix for boolean flags and `settings.` prefix for other values to ensure proper grouping in the response.
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| Cache TTL | TimeInterval | 300 (5 min) | How long config is cached in Redis |
+| Cache Key | String | `remote_config_all` | Redis key for cached response |
+
+Cache TTL is defined in `RemoteConfigController.cacheTTL`. To modify, update the constant in the controller.
+
+## Notes
+
+- The public endpoint does NOT require authentication - this is intentional for mobile app accessibility
+- Cache is automatically invalidated on any write operation, so changes are immediately visible
+- Values are stored as strings internally but transformed to proper JSON types (boolean, integer, string) in the response
+- The `AnyCodableValue` enum handles type-erased encoding/decoding for mixed-type settings


### PR DESCRIPTION
## Summary

Implement remote configuration endpoint for mobile apps to fetch feature flags and settings without requiring app updates. The module provides a public GET endpoint for apps and admin CRUD endpoints for configuration management, with Redis caching for performance.

## Changes

- Added complete RemoteConfig module with database model, repository, controller, and router
- Implemented public `GET /api/v1/config` endpoint (no authentication required)
- Implemented admin endpoints (`POST`, `PATCH`, `DELETE`, `GET /admin`) with admin authentication
- Added Redis caching with 5-minute TTL and automatic cache invalidation on write operations
- Added support for typed configuration values (boolean, integer, string)
- Added comprehensive integration tests for all endpoints and edge cases
- Added feature documentation: `docs/features/remote-config.md`
- Updated conditional docs guide with discoverability conditions

## Testing

All acceptance criteria verified through integration tests:

- **Public endpoint**: Returns config without authentication
- **Response format**: Feature flags and settings grouped correctly with proper JSON types
- **Admin CRUD**: Create, update, delete operations work for authenticated admins
- **Authorization**: Non-authenticated and non-admin users receive 401 on admin endpoints
- **Caching**: Redis cache populated on read, invalidated on write operations
- **Type validation**: Invalid value types rejected with 400 Bad Request
- **Duplicate handling**: Duplicate keys rejected with 409 Conflict

**Test Results:**
- `RemoteConfigGetTests`: 4 tests passing
- `RemoteConfigAdminTests`: 14 tests passing

## Evidence

Tests validate all acceptance criteria from story RULE-151:
- Public endpoint works without auth ✓
- Config response matches expected JSON structure ✓
- PostgreSQL persistence with Redis caching (5 min TTL) ✓
- Typed values (boolean, integer, string) supported ✓
- Admin endpoints require authentication ✓
- Non-admin users blocked from admin endpoints ✓
- Cache invalidation on write operations ✓


---
Linear: https://linear.app/rule/issue/RULE-151