### PR TITLE
RULE-136: Story 2.1: Create Receipts Module Foundation

### DIFF
--- a/Sources/App/Common/Extensions/Application+Services.swift
+++ b/Sources/App/Common/Extensions/Application+Services.swift
@@ -31,6 +31,7 @@ final class ServiceStorageContainer: @unchecked Sendable {
     var generatedRuleRepository: (any GeneratedRuleRepository)?
     var waitlistRepository: (any WaitlistRepository)?
     var remoteConfigRepository: (any RemoteConfigRepository)?
+    var receiptsRepository: (any ReceiptsRepository)?
 
     init() {}
 }
@@ -152,5 +153,10 @@ extension Application {
     var remoteConfigRepository: any RemoteConfigRepository {
         get { serviceStorage.remoteConfigRepository! }
         set { serviceStorage.remoteConfigRepository = newValue }
+    }
+
+    var receiptsRepository: any ReceiptsRepository {
+        get { serviceStorage.receiptsRepository! }
+        set { serviceStorage.receiptsRepository = newValue }
     }
 }

--- a/Sources/App/Entities/Receipts/Receipts.swift
+++ b/Sources/App/Entities/Receipts/Receipts.swift
@@ -1,0 +1,4 @@
+import Foundation
+import Vapor
+
+public enum Receipts {}

--- a/Sources/App/Entrypoint/Application-Setup.swift
+++ b/Sources/App/Entrypoint/Application-Setup.swift
@@ -88,6 +88,7 @@ extension Application {
       CacheAdminModule(),
       WaitlistModule(),
       RemoteConfigModule(),
+      ReceiptsModule(),
     ]
 
     for module in modules {
@@ -194,6 +195,7 @@ extension Application {
     generatedRuleRepository = DatabaseGeneratedRuleRepository(database: db)
     waitlistRepository = DatabaseWaitlistRepository(database: db)
     remoteConfigRepository = DatabaseRemoteConfigRepository(database: db)
+    receiptsRepository = DatabaseReceiptsRepository(database: db)
 
     // Initialize foundation services (no dependencies)
     randomGeneratorService = RealRandomGeneratorService(app: self)

--- a/Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift
+++ b/Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift
@@ -1,0 +1,4 @@
+import Fluent
+import Vapor
+
+struct ReceiptsController {}

--- a/Sources/App/Modules/Receipts/Database/Migrations/ReceiptsMigrations.swift
+++ b/Sources/App/Modules/Receipts/Database/Migrations/ReceiptsMigrations.swift
@@ -1,0 +1,32 @@
+import Fluent
+import Vapor
+
+enum ReceiptsMigrations {
+
+    struct v1: AsyncMigration {
+
+        func prepare(on db: Database) async throws {
+            try await db.enum("transaction_platform")
+                .case("ios")
+                .case("android")
+                .create()
+
+            let platformEnum = try await db.enum("transaction_platform").read()
+
+            try await db.schema(TransactionModel.schema)
+                .id()
+                .field(TransactionModel.FieldKeys.v1.transactionId, .string, .required)
+                .field(TransactionModel.FieldKeys.v1.platform, platformEnum, .required)
+                .field(TransactionModel.FieldKeys.v1.productId, .string, .required)
+                .field(TransactionModel.FieldKeys.v1.creditAmount, .int, .required)
+                .field(TransactionModel.FieldKeys.v1.createdAt, .datetime)
+                .unique(on: TransactionModel.FieldKeys.v1.transactionId)
+                .create()
+        }
+
+        func revert(on db: Database) async throws {
+            try await db.schema(TransactionModel.schema).delete()
+            try await db.enum("transaction_platform").delete()
+        }
+    }
+}

--- a/Sources/App/Modules/Receipts/Database/Models/TransactionModel.swift
+++ b/Sources/App/Modules/Receipts/Database/Models/TransactionModel.swift
@@ -1,0 +1,58 @@
+import Fluent
+import Vapor
+
+final class TransactionModel: @unchecked Sendable, DatabaseModelInterface {
+    typealias Module = ReceiptsModule
+    static var schema: String { "transactions" }
+
+    @ID()
+    var id: UUID?
+
+    @Field(key: FieldKeys.v1.transactionId)
+    var transactionId: String
+
+    @Enum(key: FieldKeys.v1.platform)
+    var platform: TransactionPlatform
+
+    @Field(key: FieldKeys.v1.productId)
+    var productId: String
+
+    @Field(key: FieldKeys.v1.creditAmount)
+    var creditAmount: Int
+
+    @Timestamp(key: FieldKeys.v1.createdAt, on: .create)
+    var createdAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        transactionId: String,
+        platform: TransactionPlatform,
+        productId: String,
+        creditAmount: Int
+    ) {
+        self.id = id
+        self.transactionId = transactionId
+        self.platform = platform
+        self.productId = productId
+        self.creditAmount = creditAmount
+    }
+}
+
+extension TransactionModel {
+    struct FieldKeys {
+        struct v1 {
+            static var transactionId: FieldKey { "transaction_id" }
+            static var platform: FieldKey { "platform" }
+            static var productId: FieldKey { "product_id" }
+            static var creditAmount: FieldKey { "credit_amount" }
+            static var createdAt: FieldKey { "created_at" }
+        }
+    }
+}
+
+public enum TransactionPlatform: String, Codable, CaseIterable, Sendable {
+    case ios
+    case android
+}

--- a/Sources/App/Modules/Receipts/Models/Receipts+Model.swift
+++ b/Sources/App/Modules/Receipts/Models/Receipts+Model.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Sources/App/Modules/Receipts/ReceiptsModule.swift
+++ b/Sources/App/Modules/Receipts/ReceiptsModule.swift
@@ -1,0 +1,12 @@
+import Vapor
+
+struct ReceiptsModule: ModuleInterface {
+
+    let router = ReceiptsRouter()
+
+    func boot(_ app: Application) throws {
+        app.migrations.add(ReceiptsMigrations.v1())
+
+        try router.boot(routes: app.routes)
+    }
+}

--- a/Sources/App/Modules/Receipts/ReceiptsRouter.swift
+++ b/Sources/App/Modules/Receipts/ReceiptsRouter.swift
@@ -1,0 +1,9 @@
+import Vapor
+import VaporToOpenAPI
+
+struct ReceiptsRouter: RouteCollection {
+
+    let controller = ReceiptsController()
+
+    func boot(routes: RoutesBuilder) throws {}
+}

--- a/Sources/App/Modules/Receipts/Repositories/ReceiptsRepository.swift
+++ b/Sources/App/Modules/Receipts/Repositories/ReceiptsRepository.swift
@@ -1,0 +1,42 @@
+import Fluent
+import Vapor
+
+protocol ReceiptsRepository: Repository {
+    func find(id: UUID) async throws -> TransactionModel?
+    func find(transactionId: String) async throws -> TransactionModel?
+    func create(_ model: TransactionModel) async throws
+    func all() async throws -> [TransactionModel]
+}
+
+struct DatabaseReceiptsRepository: ReceiptsRepository, DatabaseRepository {
+    typealias Model = TransactionModel
+
+    let database: Database
+
+    func find(id: UUID) async throws -> TransactionModel? {
+        try await TransactionModel.query(on: database)
+            .filter(\.$id == id)
+            .first()
+    }
+
+    func find(transactionId: String) async throws -> TransactionModel? {
+        try await TransactionModel.query(on: database)
+            .filter(\.$transactionId == transactionId)
+            .first()
+    }
+
+    func all() async throws -> [TransactionModel] {
+        try await TransactionModel.query(on: database)
+            .all()
+    }
+
+    func create(_ model: TransactionModel) async throws {
+        try await model.create(on: database)
+    }
+}
+
+extension Application.Repositories {
+    var receipts: any ReceiptsRepository {
+        application.receiptsRepository
+    }
+}

--- a/docs/CONDITIONAL_DOCS.md
+++ b/docs/CONDITIONAL_DOCS.md
@@ -155,3 +155,10 @@ This guide helps you find relevant documentation based on what you're working on
   - Conditions:
     - When writing or updating documentation
     - When creating new documentation files
+
+- docs/features/receipts-module.md
+  - Conditions:
+    - When implementing in-app purchase verification for the Receipts module
+    - When adding transaction storage or receipt validation endpoints
+    - When enforcing idempotency for store transaction records
+    - When working with platform-specific enums (ios/android) in database models

--- a/docs/features/receipts-module.md
+++ b/docs/features/receipts-module.md
@@ -1,0 +1,92 @@
+# Receipts Module Foundation
+
+**Date:** 2026-03-08
+**Related Files:** `Sources/App/Modules/Receipts/`, `Sources/App/Entities/Receipts/`
+
+## Overview
+
+The Receipts module provides the foundation for storing validated in-app purchase transaction records. It implements a `TransactionModel` with platform-aware storage (iOS/Android), idempotency enforcement via unique `transactionId` constraints, and a repository layer for querying existing transactions before processing duplicates.
+
+## What Was Built
+
+- `TransactionModel` database model with platform enum, product ID, and credit amount fields
+- PostgreSQL migration with `transaction_platform` enum type and unique constraint on `transactionId`
+- `ReceiptsRepository` protocol and `DatabaseReceiptsRepository` implementation with idempotency query
+- Module, router, and controller stubs for future endpoint implementation (Story 2.4)
+- Entity namespace (`Receipts`) for future request/response DTOs
+
+## Technical Implementation
+
+### Key Files
+
+- `Sources/App/Modules/Receipts/Database/Models/TransactionModel.swift`: Fluent model with `@Enum` for platform and `@Timestamp` for creation tracking
+- `Sources/App/Modules/Receipts/Database/Migrations/ReceiptsMigrations.swift`: Creates `transaction_platform` enum type and `transactions` table with unique constraint
+- `Sources/App/Modules/Receipts/Repositories/ReceiptsRepository.swift`: Repository with `find(transactionId:)` for idempotency checks
+- `Sources/App/Modules/Receipts/ReceiptsModule.swift`: Registers migration and boots router
+- `Sources/App/Common/Extensions/Application+Services.swift`: Service storage registration
+- `Sources/App/Entrypoint/Application-Setup.swift`: Module registration in boot sequence
+
+### Key Patterns
+
+- **Idempotency via Unique Constraint**: The `transactionId` field has a database-level unique constraint, preventing duplicate transaction records even under concurrent requests. The repository provides `find(transactionId:)` for application-level checks before attempting inserts.
+
+- **PostgreSQL Enum Type**: The `TransactionPlatform` enum (ios/android) is stored as a PostgreSQL enum type rather than a raw string. The migration creates the enum type first, then references it in the table schema:
+  ```swift
+  try await db.enum("transaction_platform")
+      .case("ios")
+      .case("android")
+      .create()
+
+  let platformEnum = try await db.enum("transaction_platform").read()
+
+  try await db.schema(TransactionModel.schema)
+      .field(TransactionModel.FieldKeys.v1.platform, platformEnum, .required)
+      // ...
+  ```
+
+- **Versioned Field Keys**: Field keys are namespaced under `FieldKeys.v1` to support future schema evolution without conflicts.
+
+### Code Examples
+
+**Creating a transaction record:**
+```swift
+let transaction = TransactionModel(
+    transactionId: "1000000123456789",
+    platform: .ios,
+    productId: "com.app.credits.10",
+    creditAmount: 10
+)
+try await req.repositories.receipts.create(transaction)
+```
+
+**Checking for duplicate transactions (idempotency):**
+```swift
+if let existing = try await req.repositories.receipts.find(transactionId: storeTransactionId) {
+    // Transaction already processed — return existing result
+    return existing
+}
+// Proceed with new transaction processing
+```
+
+## How to Use
+
+1. The module is registered in `Application-Setup.swift` and boots automatically
+2. The repository is available via `req.repositories.receipts` in any controller
+3. Use `find(transactionId:)` before creating records to enforce idempotency
+4. Controller endpoints will be added in Story 2.4 (Receipt Verification Endpoint)
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| Credit amounts | Int | 1, 3, or 10 | Valid credit amounts per product tier |
+| Platforms | Enum | ios, android | Supported store platforms |
+
+These values are enforced at the application level (future Story 2.4), not in the database schema.
+
+## Notes
+
+- The controller, router, and model extension files are intentional stubs — endpoint logic will be implemented in Story 2.4
+- The `Receipts` entity namespace at `Entities/Receipts/Receipts.swift` is a placeholder for future DTOs
+- Migration supports both SQLite (tests) and PostgreSQL (production)
+- The unique constraint on `transactionId` provides database-level protection against duplicate processing


### PR DESCRIPTION
## Summary

Implements the Receipts module foundation (Story 2.1 / RULE-136) for the In-App Purchase Verification system, providing the database model, migration, and repository layer for storing validated transaction records.

## Changes

- Created `TransactionModel` with fields: `transactionId`, `platform` (ios/android enum), `productId`, `creditAmount`, `createdAt`
- Created `ReceiptsMigrations.v1` with PostgreSQL enum type and unique constraint on `transactionId`
- Created `ReceiptsRepository` protocol and `DatabaseReceiptsRepository` with `find(transactionId:)` for idempotency
- Created `ReceiptsModule`, `ReceiptsRouter`, `ReceiptsController` stubs following established module pattern
- Created `Receipts` entity namespace and `Receipts+Model` placeholder for future DTOs
- Registered `ReceiptsModule` in `Application-Setup.swift` and `DatabaseReceiptsRepository` in `Application+Services.swift`
- Added feature documentation: `docs/features/receipts-module.md`
- Updated conditional docs guide with discoverability conditions

## Testing

- Project compiles successfully with `swift build`
- All existing tests pass with no regressions
- Codex adversarial review performed: 8 findings (1 HIGH, 4 MEDIUM, 3 LOW) — all validated as false positives or acceptable for the current story scope (stubs are intentional for Story 2.4)

## Evidence

- Build: successful (196.99s compilation)
- Tests: all passing, no regressions
- Codex review: all findings validated against code and story requirements


---
Linear: https://linear.app/rule/issue/RULE-136