### PR TITLE
RULE-252: Story 2.2: Implement App Store Receipt Validation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/redis.git", from: "4.0.0"),
         .package(url: "https://github.com/binarybirds/swift-html", from: "1.7.0"),
         .package(url: "https://github.com/dankinsoid/VaporToOpenAPI.git", from: "4.8.1"),
+        .package(url: "https://github.com/apple/app-store-server-library-swift.git", "2.0.0"..<"3.0.0"),
     ],
     targets: [
         .executableTarget(
@@ -34,6 +35,7 @@ let package = Package(
                 .product(name: "JWT", package: "jwt"),
                 .product(name: "Redis", package: "redis"),
                 .product(name: "VaporToOpenAPI", package: "VaporToOpenAPI"),
+                .product(name: "AppStoreServerLibrary", package: "app-store-server-library-swift"),
             ]
         ),
         .testTarget(

--- a/Sources/App/Common/Extensions/Application+Services.swift
+++ b/Sources/App/Common/Extensions/Application+Services.swift
@@ -21,6 +21,7 @@ final class ServiceStorageContainer: @unchecked Sendable {
     var uuidGeneratorService: UUIDGeneratorService?
     var aiResponseValidatorService: AIResponseValidationService?
     var remoteConfigCacheService: RemoteConfigCacheService?
+    var appStoreValidationService: AppStoreValidationService?
 
     // MARK: - Repositories
 
@@ -116,6 +117,11 @@ extension Application {
     var aiResponseValidatorService: AIResponseValidationService {
         get { serviceStorage.aiResponseValidatorService! }
         set { serviceStorage.aiResponseValidatorService = newValue }
+    }
+
+    var appStoreValidationService: AppStoreValidationService {
+        get { serviceStorage.appStoreValidationService! }
+        set { serviceStorage.appStoreValidationService = newValue }
     }
 
     // MARK: - Repositories

--- a/Sources/App/Common/Extensions/Request+Services.swift
+++ b/Sources/App/Common/Extensions/Request+Services.swift
@@ -64,4 +64,8 @@ struct RequestServices: @unchecked Sendable {
     var aiResponseValidator: AIResponseValidationService {
         app.aiResponseValidatorService
     }
+
+    var appStoreValidation: AppStoreValidationService {
+        app.appStoreValidationService
+    }
 }

--- a/Sources/App/Entrypoint/Application-Setup.swift
+++ b/Sources/App/Entrypoint/Application-Setup.swift
@@ -209,6 +209,7 @@ extension Application {
     // Initialize external services
     emailService = BrevoClient(app: self)
     llmService = GoogleGeminiService(app: self)
+    appStoreValidationService = DefaultAppStoreValidationService(app: self)
 
     // Initialize Redis-based services
     let redisConfig = try configuration.redis

--- a/Sources/App/Modules/Receipts/Services/AppStoreValidationService.swift
+++ b/Sources/App/Modules/Receipts/Services/AppStoreValidationService.swift
@@ -145,7 +145,9 @@ final class DefaultAppStoreValidationService: AppStoreValidationService, @unchec
         guard let purchaseDate = transaction.purchaseDate else {
             throw AppStoreValidationError.verificationFailed("Missing purchaseDate in decoded payload")
         }
-        let environment = transaction.environment?.rawValue ?? "Unknown"
+        guard let environment = transaction.environment?.rawValue else {
+            throw AppStoreValidationError.verificationFailed("Missing environment in decoded payload")
+        }
 
         app.logger.info("App Store transaction verified successfully", metadata: [
             "transactionId": .string(transactionId),
@@ -169,7 +171,7 @@ final class DefaultAppStoreValidationService: AppStoreValidationService, @unchec
         case .INVALID_CERTIFICATE:
             return .invalidCertificateChain
         case .VERIFICATION_FAILURE:
-            return .invalidSignature
+            return .verificationFailed("Signature verification failed")
         case .INVALID_APP_IDENTIFIER:
             return .bundleIdMismatch
         case .INVALID_ENVIRONMENT:

--- a/Sources/App/Modules/Receipts/Services/AppStoreValidationService.swift
+++ b/Sources/App/Modules/Receipts/Services/AppStoreValidationService.swift
@@ -102,8 +102,17 @@ final class DefaultAppStoreValidationService: AppStoreValidationService, @unchec
 
         let rootCertificates = try loadAppleRootCertificates()
 
-        let environment: AppStoreServerLibrary.Environment =
-            config.environment.lowercased() == "production" ? .production : .sandbox
+        let environment: AppStoreServerLibrary.Environment
+        switch config.environment.lowercased() {
+        case "production":
+            environment = .production
+        case "sandbox":
+            environment = .sandbox
+        default:
+            throw AppStoreValidationError.configurationError(
+                "Invalid APPLE_ENVIRONMENT '\(config.environment)'. Must be 'production' or 'sandbox'."
+            )
+        }
 
         do {
             return try SignedDataVerifier(
@@ -133,7 +142,9 @@ final class DefaultAppStoreValidationService: AppStoreValidationService, @unchec
             throw AppStoreValidationError.verificationFailed("Missing bundleId in decoded payload")
         }
 
-        let purchaseDate = transaction.purchaseDate ?? Date()
+        guard let purchaseDate = transaction.purchaseDate else {
+            throw AppStoreValidationError.verificationFailed("Missing purchaseDate in decoded payload")
+        }
         let environment = transaction.environment?.rawValue ?? "Unknown"
 
         app.logger.info("App Store transaction verified successfully", metadata: [

--- a/Sources/App/Modules/Receipts/Services/AppStoreValidationService.swift
+++ b/Sources/App/Modules/Receipts/Services/AppStoreValidationService.swift
@@ -1,0 +1,185 @@
+import AppStoreServerLibrary
+import Foundation
+import Vapor
+
+// MARK: - Validation Result
+
+/// Result of a successful App Store transaction verification.
+struct AppStoreValidationResult: Sendable {
+    /// The unique transaction identifier.
+    let transactionId: String
+
+    /// The product identifier from App Store Connect.
+    let productId: String
+
+    /// The bundle identifier of the app that made the purchase.
+    let bundleId: String
+
+    /// The date when the purchase was made.
+    let purchaseDate: Date
+
+    /// The App Store environment (e.g., "Sandbox" or "Production").
+    let environment: String
+}
+
+// MARK: - Validation Errors
+
+/// Errors that can occur during App Store receipt validation.
+enum AppStoreValidationError: Error, Equatable {
+    /// The JWS signature verification failed.
+    case invalidSignature
+
+    /// The certificate chain in the JWS could not be verified.
+    case invalidCertificateChain
+
+    /// The bundle ID in the transaction doesn't match the configured bundle ID.
+    case bundleIdMismatch
+
+    /// The service is not properly configured (missing credentials or certificates).
+    case configurationError(String)
+
+    /// A general verification failure with a descriptive reason.
+    case verificationFailed(String)
+}
+
+// MARK: - Protocol
+
+/// Service responsible for verifying App Store signed transactions.
+///
+/// This service validates JWS (JSON Web Signature) signed transaction data
+/// from Apple's App Store using Apple's root certificates and the
+/// App Store Server Library.
+protocol AppStoreValidationService: Sendable {
+    /// Verifies a signed transaction from the App Store.
+    ///
+    /// - Parameter signedTransaction: The JWS-encoded signed transaction string from the client.
+    /// - Returns: The validated transaction details.
+    /// - Throws: ``AppStoreValidationError`` if verification fails.
+    func verify(signedTransaction: String) async throws -> AppStoreValidationResult
+}
+
+// MARK: - Implementation
+
+/// Default implementation of ``AppStoreValidationService`` using Apple's App Store Server Library.
+///
+/// Uses ``SignedDataVerifier`` from `AppStoreServerLibrary` to verify JWS transactions
+/// with Apple's x5c certificate chain. The verifier handles signature validation,
+/// certificate chain verification, and environment checking.
+final class DefaultAppStoreValidationService: AppStoreValidationService, @unchecked Sendable {
+    let app: Application
+
+    init(app: Application) {
+        self.app = app
+    }
+
+    func verify(signedTransaction: String) async throws -> AppStoreValidationResult {
+        let verifier = try createVerifier()
+
+        let result = await verifier.verifyAndDecodeTransaction(signedTransaction: signedTransaction)
+
+        switch result {
+        case .valid(let transaction):
+            return try extractResult(from: transaction)
+        case .invalid(let error):
+            app.logger.warning("App Store transaction verification failed", metadata: [
+                "error": .string(String(describing: error))
+            ])
+            throw mapVerificationError(error)
+        }
+    }
+
+    // MARK: - Private
+
+    private func createVerifier() throws -> SignedDataVerifier {
+        let config: AppleConfig
+        do {
+            config = try app.configuration.apple
+        } catch {
+            throw AppStoreValidationError.configurationError(
+                "Failed to load Apple configuration: \(error)"
+            )
+        }
+
+        let rootCertificates = try loadAppleRootCertificates()
+
+        let environment: AppStoreServerLibrary.Environment =
+            config.environment.lowercased() == "production" ? .production : .sandbox
+
+        do {
+            return try SignedDataVerifier(
+                rootCertificates: rootCertificates,
+                bundleId: config.bundleId,
+                appAppleId: config.appAppleId,
+                environment: environment,
+                enableOnlineChecks: true
+            )
+        } catch {
+            throw AppStoreValidationError.configurationError(
+                "Failed to create SignedDataVerifier: \(error)"
+            )
+        }
+    }
+
+    private func extractResult(from transaction: JWSTransactionDecodedPayload) throws -> AppStoreValidationResult {
+        guard let transactionId = transaction.transactionId else {
+            throw AppStoreValidationError.verificationFailed("Missing transactionId in decoded payload")
+        }
+
+        guard let productId = transaction.productId else {
+            throw AppStoreValidationError.verificationFailed("Missing productId in decoded payload")
+        }
+
+        guard let bundleId = transaction.bundleId else {
+            throw AppStoreValidationError.verificationFailed("Missing bundleId in decoded payload")
+        }
+
+        let purchaseDate = transaction.purchaseDate ?? Date()
+        let environment = transaction.environment?.rawValue ?? "Unknown"
+
+        app.logger.info("App Store transaction verified successfully", metadata: [
+            "transactionId": .string(transactionId),
+            "productId": .string(productId),
+            "bundleId": .string(bundleId)
+        ])
+
+        return AppStoreValidationResult(
+            transactionId: transactionId,
+            productId: productId,
+            bundleId: bundleId,
+            purchaseDate: purchaseDate,
+            environment: environment
+        )
+    }
+
+    private func mapVerificationError(_ error: VerificationError) -> AppStoreValidationError {
+        switch error {
+        case .INVALID_JWT_FORMAT:
+            return .invalidSignature
+        case .INVALID_CERTIFICATE:
+            return .invalidCertificateChain
+        case .VERIFICATION_FAILURE:
+            return .invalidSignature
+        case .INVALID_APP_IDENTIFIER:
+            return .bundleIdMismatch
+        case .INVALID_ENVIRONMENT:
+            return .verificationFailed("Environment mismatch between transaction and configuration")
+        }
+    }
+
+    /// Loads Apple Root CA certificates for JWS signature verification.
+    ///
+    /// Uses the Apple Root CA - G3 certificate, which is the root certificate
+    /// for the App Store Server API's signing chain.
+    /// Source: https://www.apple.com/certificateauthority/
+    private func loadAppleRootCertificates() throws -> [Foundation.Data] {
+        // Apple Root CA - G3 (DER-encoded, base64)
+        // Verified against Apple's official app-store-server-library-swift test suite
+        let appleRootCAG3Base64 = "MIICQzCCAcmgAwIBAgIILcX8iNLFS5UwCgYIKoZIzj0EAwMwZzEbMBkGA1UEAwwSQXBwbGUgUm9vdCBDQSAtIEczMSYwJAYDVQQLDB1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTQwNDMwMTgxOTA2WhcNMzkwNDMwMTgxOTA2WjBnMRswGQYDVQQDDBJBcHBsZSBSb290IENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzB2MBAGByqGSM49AgEGBSuBBAAiA2IABJjpLz1AcqTtkyJygRMc3RCV8cWjTnHcFBbZDuWmBSp3ZHtfTjjTuxxEtX/1H7YyYl3J6YRbTzBPEVoA/VhYDKX1DyxNB0cTddqXl5dvMVztK517IDvYuVTZXpmkOlEKMaNCMEAwHQYDVR0OBBYEFLuw3qFYM4iapIqZ3r6966/ayySrMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMDA2gAMGUCMQCD6cHEFl4aXTQY2e3v9GwOAEZLuN+yRhHFD/3meoyhpmvOwgPUnPWTxnS4at+qIxUCMG1mihDK1A3UT82NQz60imOlM27jbdoXt2QfyFMm+YhidDkLF1vLUagM6BgD56KyKA=="
+
+        guard let certData = Foundation.Data(base64Encoded: appleRootCAG3Base64) else {
+            throw AppStoreValidationError.configurationError("Failed to decode Apple Root CA G3 certificate")
+        }
+
+        return [certData]
+    }
+}

--- a/Sources/App/Services/Configuration/ConfigurationService.swift
+++ b/Sources/App/Services/Configuration/ConfigurationService.swift
@@ -80,13 +80,24 @@ protocol ConfigurationService: Sendable {
   ///
   /// Provides configuration for Redis-based caching which offers:
   /// - Persistent cache storage across server restarts
-  /// - Distributed caching for multi-instance deployments  
+  /// - Distributed caching for multi-instance deployments
   /// - Higher performance than in-memory caching for large datasets
   /// - Advanced features like atomic operations and pub/sub
   ///
   /// - Returns: Redis configuration with connection and pooling settings
   /// - Throws: ``ConfigurationError`` if Redis settings are invalid
   var redis: RedisConfig { get throws }
+
+  /// Apple App Store configuration for receipt validation.
+  ///
+  /// Contains credentials for:
+  /// - App Store Server API authentication
+  /// - Signed transaction (JWS) verification
+  /// - Bundle ID validation
+  ///
+  /// - Returns: Apple configuration with API credentials and app identifiers
+  /// - Throws: ``ConfigurationError`` if Apple settings are missing or invalid
+  var apple: AppleConfig { get throws }
 
   /// Validates all configuration settings for the current environment.
   ///

--- a/Sources/App/Services/Configuration/ConfigurationTypes.swift
+++ b/Sources/App/Services/Configuration/ConfigurationTypes.swift
@@ -266,3 +266,27 @@ public struct RedisConfig: Sendable {
     /// Useful for debugging and performance monitoring.
     public let enableLogging: Bool
 }
+
+/// Apple App Store configuration for In-App Purchase receipt validation.
+///
+/// Contains credentials and settings required to verify App Store signed
+/// transactions using Apple's App Store Server Library.
+struct AppleConfig: Sendable {
+    /// The issuer ID from App Store Connect (used for App Store Server API).
+    let issuerId: String
+
+    /// The key ID for the App Store Connect API key.
+    let keyId: String
+
+    /// The private key content (PEM format) for App Store Connect API authentication.
+    let privateKey: String
+
+    /// The bundle identifier of the iOS application.
+    let bundleId: String
+
+    /// The numeric App ID from App Store Connect.
+    let appAppleId: Int64
+
+    /// The App Store environment: "sandbox" or "production".
+    let environment: String
+}

--- a/Sources/App/Services/Configuration/DevelopmentConfiguration.swift
+++ b/Sources/App/Services/Configuration/DevelopmentConfiguration.swift
@@ -90,6 +90,19 @@ struct DevelopmentConfiguration: ConfigurationService {
     }
   }
 
+  var apple: AppleConfig {
+    get throws {
+      AppleConfig(
+        issuerId: Environment.get("APPLE_ISSUER_ID") ?? "dev_issuer_id",
+        keyId: Environment.get("APPLE_KEY_ID") ?? "dev_key_id",
+        privateKey: Environment.get("APPLE_PRIVATE_KEY") ?? "dev_private_key",
+        bundleId: Environment.get("APP_BUNDLE_ID") ?? "com.dev.app",
+        appAppleId: Int64(Environment.get("APP_APPLE_ID") ?? "123456789") ?? 123456789,
+        environment: Environment.get("APPLE_ENVIRONMENT") ?? "sandbox"
+      )
+    }
+  }
+
   func validate() throws {
     let db = try database
 

--- a/Sources/App/Services/Configuration/ProductionConfiguration.swift
+++ b/Sources/App/Services/Configuration/ProductionConfiguration.swift
@@ -314,6 +314,7 @@ struct ProductionConfiguration: ConfigurationService {
     let cache = try cache
     _ = try aws
     _ = try apns
+    _ = try apple
 
     // Database validation
     if db.port < 1 || db.port > 65535 {

--- a/Sources/App/Services/Configuration/ProductionConfiguration.swift
+++ b/Sources/App/Services/Configuration/ProductionConfiguration.swift
@@ -296,13 +296,22 @@ struct ProductionConfiguration: ConfigurationService {
         )
       }
 
+      let environment = Environment.get("APPLE_ENVIRONMENT") ?? "production"
+      guard environment == "production" || environment == "sandbox" else {
+        throw ConfigurationError.invalidFormat(
+          key: "APPLE_ENVIRONMENT",
+          expected: "'production' or 'sandbox'",
+          got: environment
+        )
+      }
+
       return AppleConfig(
         issuerId: issuerId,
         keyId: keyId,
         privateKey: privateKey,
         bundleId: bundleId,
         appAppleId: appAppleId,
-        environment: Environment.get("APPLE_ENVIRONMENT") ?? "production"
+        environment: environment
       )
     }
   }

--- a/Sources/App/Services/Configuration/ProductionConfiguration.swift
+++ b/Sources/App/Services/Configuration/ProductionConfiguration.swift
@@ -258,6 +258,55 @@ struct ProductionConfiguration: ConfigurationService {
     }
   }
 
+  var apple: AppleConfig {
+    get throws {
+      guard let issuerId = Environment.get("APPLE_ISSUER_ID") else {
+        throw ConfigurationError.missingRequired(
+          key: "APPLE_ISSUER_ID",
+          suggestion: "Set APPLE_ISSUER_ID environment variable from App Store Connect"
+        )
+      }
+
+      guard let keyId = Environment.get("APPLE_KEY_ID") else {
+        throw ConfigurationError.missingRequired(
+          key: "APPLE_KEY_ID",
+          suggestion: "Set APPLE_KEY_ID environment variable from App Store Connect"
+        )
+      }
+
+      guard let privateKey = Environment.get("APPLE_PRIVATE_KEY") else {
+        throw ConfigurationError.missingRequired(
+          key: "APPLE_PRIVATE_KEY",
+          suggestion: "Set APPLE_PRIVATE_KEY environment variable with the .p8 key content"
+        )
+      }
+
+      guard let bundleId = Environment.get("APP_BUNDLE_ID") else {
+        throw ConfigurationError.missingRequired(
+          key: "APP_BUNDLE_ID",
+          suggestion: "Set APP_BUNDLE_ID environment variable (e.g., com.yourcompany.app)"
+        )
+      }
+
+      guard let appAppleIdString = Environment.get("APP_APPLE_ID"),
+            let appAppleId = Int64(appAppleIdString) else {
+        throw ConfigurationError.missingRequired(
+          key: "APP_APPLE_ID",
+          suggestion: "Set APP_APPLE_ID environment variable with the numeric App ID from App Store Connect"
+        )
+      }
+
+      return AppleConfig(
+        issuerId: issuerId,
+        keyId: keyId,
+        privateKey: privateKey,
+        bundleId: bundleId,
+        appAppleId: appAppleId,
+        environment: Environment.get("APPLE_ENVIRONMENT") ?? "production"
+      )
+    }
+  }
+
   func validate() throws {
     let db = try database
     let services = try services

--- a/Sources/App/Services/Configuration/TestingConfiguration.swift
+++ b/Sources/App/Services/Configuration/TestingConfiguration.swift
@@ -84,6 +84,19 @@ struct TestingConfiguration: ConfigurationService {
     }
   }
 
+  var apple: AppleConfig {
+    get throws {
+      AppleConfig(
+        issuerId: "test_issuer_id",
+        keyId: "test_key_id",
+        privateKey: "test_private_key",
+        bundleId: "com.test.app",
+        appAppleId: 123456789,
+        environment: "sandbox"
+      )
+    }
+  }
+
   func validate() throws {
     // Minimal validation for tests - all values are hardcoded and valid
   }

--- a/Tests/AppTests/Services/Receipts/AppStoreValidationServiceTests.swift
+++ b/Tests/AppTests/Services/Receipts/AppStoreValidationServiceTests.swift
@@ -1,0 +1,247 @@
+@testable import App
+import Testing
+import VaporTesting
+
+@Suite(.serialized)
+struct AppStoreValidationServiceTests {
+
+    // MARK: - AppStoreValidationResult Tests
+
+    @Test("Validation result captures all required fields", .tags(.unit))
+    func validationResultFields() {
+        let date = Date(timeIntervalSince1970: 1700000000)
+        let result = AppStoreValidationResult(
+            transactionId: "txn_123",
+            productId: "com.app.credits.100",
+            bundleId: "com.test.app",
+            purchaseDate: date,
+            environment: "Sandbox"
+        )
+
+        #expect(result.transactionId == "txn_123")
+        #expect(result.productId == "com.app.credits.100")
+        #expect(result.bundleId == "com.test.app")
+        #expect(result.purchaseDate == date)
+        #expect(result.environment == "Sandbox")
+    }
+
+    // MARK: - AppStoreValidationError Tests
+
+    @Test("Error cases are equatable", .tags(.unit))
+    func errorEquatable() {
+        #expect(AppStoreValidationError.invalidSignature == AppStoreValidationError.invalidSignature)
+        #expect(AppStoreValidationError.invalidCertificateChain == AppStoreValidationError.invalidCertificateChain)
+        #expect(AppStoreValidationError.bundleIdMismatch == AppStoreValidationError.bundleIdMismatch)
+        #expect(AppStoreValidationError.configurationError("a") == AppStoreValidationError.configurationError("a"))
+        #expect(AppStoreValidationError.configurationError("a") != AppStoreValidationError.configurationError("b"))
+        #expect(AppStoreValidationError.verificationFailed("x") == AppStoreValidationError.verificationFailed("x"))
+        #expect(AppStoreValidationError.invalidSignature != AppStoreValidationError.bundleIdMismatch)
+    }
+
+    @Test("All error cases are distinct", .tags(.unit))
+    func errorCasesDistinct() {
+        let cases: [AppStoreValidationError] = [
+            .invalidSignature,
+            .invalidCertificateChain,
+            .bundleIdMismatch,
+            .configurationError("test"),
+            .verificationFailed("test"),
+        ]
+
+        for i in 0..<cases.count {
+            for j in (i + 1)..<cases.count {
+                #expect(cases[i] != cases[j], "Expected \(cases[i]) != \(cases[j])")
+            }
+        }
+    }
+
+    @Test("Error conforms to Error protocol", .tags(.unit))
+    func errorConformsToError() {
+        let error: Error = AppStoreValidationError.invalidSignature
+        #expect(error is AppStoreValidationError)
+    }
+
+    // MARK: - DefaultAppStoreValidationService Tests
+
+    @Test("Service rejects invalid JWS with appropriate error", .tags(.unit))
+    func rejectInvalidJWS() async throws {
+        let app = try await Application.make(.testing)
+        defer { Task { try await app.asyncShutdown() } }
+        try app.initializeConfiguration()
+
+        let service = DefaultAppStoreValidationService(app: app)
+
+        do {
+            _ = try await service.verify(signedTransaction: "not-a-valid-jws")
+            Issue.record("Expected AppStoreValidationError to be thrown")
+        } catch let error as AppStoreValidationError {
+            switch error {
+            case .invalidSignature, .invalidCertificateChain:
+                break // Expected
+            default:
+                Issue.record("Expected invalidSignature or invalidCertificateChain, got \(error)")
+            }
+        }
+    }
+
+    @Test("Service rejects empty signed transaction", .tags(.unit))
+    func rejectEmptyTransaction() async throws {
+        let app = try await Application.make(.testing)
+        defer { Task { try await app.asyncShutdown() } }
+        try app.initializeConfiguration()
+
+        let service = DefaultAppStoreValidationService(app: app)
+
+        do {
+            _ = try await service.verify(signedTransaction: "")
+            Issue.record("Expected AppStoreValidationError to be thrown")
+        } catch let error as AppStoreValidationError {
+            switch error {
+            case .invalidSignature, .invalidCertificateChain:
+                break // Expected
+            default:
+                Issue.record("Expected invalidSignature or invalidCertificateChain, got \(error)")
+            }
+        }
+    }
+
+    @Test("Service rejects tampered JWS with three parts", .tags(.unit))
+    func rejectTamperedJWS() async throws {
+        let app = try await Application.make(.testing)
+        defer { Task { try await app.asyncShutdown() } }
+        try app.initializeConfiguration()
+
+        let service = DefaultAppStoreValidationService(app: app)
+
+        // A JWS has three base64url-encoded parts separated by dots
+        let tamperedJWS = "eyJhbGciOiJFUzI1NiJ9.eyJ0ZXN0IjoidGVzdCJ9.invalid_signature"
+
+        do {
+            _ = try await service.verify(signedTransaction: tamperedJWS)
+            Issue.record("Expected AppStoreValidationError to be thrown")
+        } catch let error as AppStoreValidationError {
+            switch error {
+            case .invalidSignature, .invalidCertificateChain:
+                break // Expected
+            default:
+                Issue.record("Expected invalidSignature or invalidCertificateChain, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Mock Service Tests (protocol testability)
+
+    @Test("Mock service can return success result", .tags(.unit))
+    func mockServiceSuccess() async throws {
+        let mockService = MockAppStoreValidationService()
+        let date = Date()
+        mockService.resultToReturn = AppStoreValidationResult(
+            transactionId: "mock_txn",
+            productId: "com.app.product",
+            bundleId: "com.test.app",
+            purchaseDate: date,
+            environment: "Sandbox"
+        )
+
+        let result = try await mockService.verify(signedTransaction: "any-signed-data")
+        #expect(result.transactionId == "mock_txn")
+        #expect(result.productId == "com.app.product")
+        #expect(result.bundleId == "com.test.app")
+        #expect(result.environment == "Sandbox")
+        #expect(mockService.verifyCallCount == 1)
+        #expect(mockService.lastSignedTransaction == "any-signed-data")
+    }
+
+    @Test("Mock service can throw invalidSignature error", .tags(.unit))
+    func mockServiceInvalidSignature() async throws {
+        let mockService = MockAppStoreValidationService()
+        mockService.errorToThrow = .invalidSignature
+
+        do {
+            _ = try await mockService.verify(signedTransaction: "any")
+            Issue.record("Expected error to be thrown")
+        } catch let error as AppStoreValidationError {
+            #expect(error == .invalidSignature)
+        }
+        #expect(mockService.verifyCallCount == 1)
+    }
+
+    @Test("Mock service can throw bundleIdMismatch error", .tags(.unit))
+    func mockServiceBundleIdMismatch() async throws {
+        let mockService = MockAppStoreValidationService()
+        mockService.errorToThrow = .bundleIdMismatch
+
+        do {
+            _ = try await mockService.verify(signedTransaction: "signed-data")
+            Issue.record("Expected error to be thrown")
+        } catch let error as AppStoreValidationError {
+            #expect(error == .bundleIdMismatch)
+        }
+    }
+
+    @Test("Mock service tracks call count correctly", .tags(.unit))
+    func mockServiceCallTracking() async throws {
+        let mockService = MockAppStoreValidationService()
+        mockService.resultToReturn = AppStoreValidationResult(
+            transactionId: "t1", productId: "p1", bundleId: "b1",
+            purchaseDate: Date(), environment: "Sandbox"
+        )
+
+        _ = try await mockService.verify(signedTransaction: "first")
+        _ = try await mockService.verify(signedTransaction: "second")
+        _ = try await mockService.verify(signedTransaction: "third")
+
+        #expect(mockService.verifyCallCount == 3)
+        #expect(mockService.lastSignedTransaction == "third")
+    }
+
+    @Test("Mock service reset clears state", .tags(.unit))
+    func mockServiceReset() async throws {
+        let mockService = MockAppStoreValidationService()
+        mockService.resultToReturn = AppStoreValidationResult(
+            transactionId: "t1", productId: "p1", bundleId: "b1",
+            purchaseDate: Date(), environment: "Sandbox"
+        )
+        _ = try await mockService.verify(signedTransaction: "test")
+
+        mockService.reset()
+
+        #expect(mockService.verifyCallCount == 0)
+        #expect(mockService.lastSignedTransaction == nil)
+        #expect(mockService.resultToReturn == nil)
+        #expect(mockService.errorToThrow == nil)
+    }
+}
+
+// MARK: - Mock Implementation
+
+/// Mock implementation of AppStoreValidationService for testing.
+/// Demonstrates the protocol can be mocked for controller tests in later stories.
+final class MockAppStoreValidationService: AppStoreValidationService, @unchecked Sendable {
+    var resultToReturn: AppStoreValidationResult?
+    var errorToThrow: AppStoreValidationError?
+    var verifyCallCount = 0
+    var lastSignedTransaction: String?
+
+    func verify(signedTransaction: String) async throws -> AppStoreValidationResult {
+        verifyCallCount += 1
+        lastSignedTransaction = signedTransaction
+
+        if let error = errorToThrow {
+            throw error
+        }
+
+        guard let result = resultToReturn else {
+            throw AppStoreValidationError.configurationError("Mock not configured")
+        }
+
+        return result
+    }
+
+    func reset() {
+        resultToReturn = nil
+        errorToThrow = nil
+        verifyCallCount = 0
+        lastSignedTransaction = nil
+    }
+}

--- a/Tests/AppTests/Services/Receipts/AppStoreValidationServiceTests.swift
+++ b/Tests/AppTests/Services/Receipts/AppStoreValidationServiceTests.swift
@@ -66,7 +66,6 @@ struct AppStoreValidationServiceTests {
     @Test("Service rejects invalid JWS with appropriate error", .tags(.unit))
     func rejectInvalidJWS() async throws {
         let app = try await Application.make(.testing)
-        defer { Task { try await app.asyncShutdown() } }
         try app.initializeConfiguration()
 
         let service = DefaultAppStoreValidationService(app: app)
@@ -82,12 +81,13 @@ struct AppStoreValidationServiceTests {
                 Issue.record("Expected invalidSignature or invalidCertificateChain, got \(error)")
             }
         }
+
+        try await app.asyncShutdown()
     }
 
     @Test("Service rejects empty signed transaction", .tags(.unit))
     func rejectEmptyTransaction() async throws {
         let app = try await Application.make(.testing)
-        defer { Task { try await app.asyncShutdown() } }
         try app.initializeConfiguration()
 
         let service = DefaultAppStoreValidationService(app: app)
@@ -103,12 +103,13 @@ struct AppStoreValidationServiceTests {
                 Issue.record("Expected invalidSignature or invalidCertificateChain, got \(error)")
             }
         }
+
+        try await app.asyncShutdown()
     }
 
     @Test("Service rejects tampered JWS with three parts", .tags(.unit))
     func rejectTamperedJWS() async throws {
         let app = try await Application.make(.testing)
-        defer { Task { try await app.asyncShutdown() } }
         try app.initializeConfiguration()
 
         let service = DefaultAppStoreValidationService(app: app)
@@ -127,6 +128,8 @@ struct AppStoreValidationServiceTests {
                 Issue.record("Expected invalidSignature or invalidCertificateChain, got \(error)")
             }
         }
+
+        try await app.asyncShutdown()
     }
 
     // MARK: - Mock Service Tests (protocol testability)

--- a/docs/CONDITIONAL_DOCS.md
+++ b/docs/CONDITIONAL_DOCS.md
@@ -162,3 +162,11 @@ This guide helps you find relevant documentation based on what you're working on
     - When adding transaction storage or receipt validation endpoints
     - When enforcing idempotency for store transaction records
     - When working with platform-specific enums (ios/android) in database models
+
+- docs/features/app-store-validation.md
+  - Conditions:
+    - When implementing App Store receipt or transaction validation in the Receipts module
+    - When configuring Apple App Store credentials or environment variables
+    - When adding new platform-specific purchase verification services
+    - When troubleshooting App Store JWS signature verification failures
+    - When upgrading the app-store-server-library-swift dependency

--- a/docs/features/app-store-validation.md
+++ b/docs/features/app-store-validation.md
@@ -1,0 +1,87 @@
+# App Store Signed Transaction Validation
+
+**Date:** 2026-03-08
+**Related Files:** `Sources/App/Modules/Receipts/Services/AppStoreValidationService.swift`, `Sources/App/Services/Configuration/ConfigurationTypes.swift`
+
+## Overview
+
+Server-side verification of Apple App Store signed transactions (JWS) using Apple's `app-store-server-library-swift`. The service decodes and cryptographically validates JWS-encoded transaction data against Apple's root certificates, ensuring purchases are legitimate before crediting users.
+
+## What Was Built
+
+- `AppStoreValidationService` protocol for transaction verification
+- `DefaultAppStoreValidationService` implementation using Apple's `SignedDataVerifier`
+- `AppStoreValidationResult` struct capturing transaction details (ID, product, bundle, date, environment)
+- `AppStoreValidationError` enum with specific failure cases
+- `AppleConfig` configuration type with 6 environment variables
+- `MockAppStoreValidationService` for use in controller tests (Story 2.4)
+
+## Technical Implementation
+
+### Key Files
+
+- `Sources/App/Modules/Receipts/Services/AppStoreValidationService.swift`: Protocol, result type, error type, and default implementation
+- `Sources/App/Services/Configuration/ConfigurationTypes.swift`: `AppleConfig` struct definition
+- `Sources/App/Services/Configuration/ProductionConfiguration.swift`: Production env var loading with strict validation
+- `Sources/App/Common/Extensions/Application+Services.swift`: Service registration in DI container
+- `Sources/App/Common/Extensions/Request+Services.swift`: Request-scoped service accessor
+- `Tests/AppTests/Services/Receipts/AppStoreValidationServiceTests.swift`: Unit tests with mock service
+
+### Key Patterns
+
+- **SignedDataVerifier Delegation**: Rather than manually parsing JWS tokens, the service delegates to Apple's `SignedDataVerifier` which handles signature verification, certificate chain validation, bundle ID matching, and environment checking. This ensures verification stays current with Apple's security requirements.
+
+- **Embedded Root Certificate**: The Apple Root CA G3 certificate is embedded as a base64 string rather than loaded from a file. This avoids deployment path issues and matches the approach used in Apple's own test suite. The certificate is DER-encoded and decoded at runtime.
+
+- **Error Mapping**: Apple's `VerificationError` cases are mapped to domain-specific `AppStoreValidationError` cases, keeping the App Store library as an implementation detail behind the protocol.
+
+- **Environment-Aware Verification**: The `SignedDataVerifier` is initialized with the configured environment (sandbox/production), ensuring sandbox transactions are rejected in production and vice versa.
+
+### Code Examples
+
+**Verifying a signed transaction (in a controller):**
+```swift
+let result = try await req.services.appStoreValidation.verify(
+    signedTransaction: requestBody.signedTransaction
+)
+// result.transactionId, result.productId, result.bundleId available
+```
+
+**Using the mock in tests:**
+```swift
+let mock = MockAppStoreValidationService()
+mock.resultToReturn = AppStoreValidationResult(
+    transactionId: "txn_123",
+    productId: "com.app.credits.100",
+    bundleId: "com.test.app",
+    purchaseDate: Date(),
+    environment: "Sandbox"
+)
+// Inject mock into test context
+```
+
+## How to Use
+
+1. Set the required environment variables (see Configuration below)
+2. The service is registered automatically in `Application-Setup.swift`
+3. Access via `req.services.appStoreValidation` in any controller
+4. Pass the client's signed transaction string to `verify(signedTransaction:)`
+5. Handle `AppStoreValidationError` for invalid/tampered transactions
+
+## Configuration
+
+| Variable | Type | Required | Default (Dev) | Description |
+|----------|------|----------|---------------|-------------|
+| `APPLE_ISSUER_ID` | String | Production | `dev_issuer_id` | Issuer ID from App Store Connect |
+| `APPLE_KEY_ID` | String | Production | `dev_key_id` | API key ID from App Store Connect |
+| `APPLE_PRIVATE_KEY` | String | Production | `dev_private_key` | .p8 private key content |
+| `APP_BUNDLE_ID` | String | Production | `com.dev.app` | iOS app bundle identifier |
+| `APP_APPLE_ID` | Int64 | Production | `123456789` | Numeric App ID from App Store Connect |
+| `APPLE_ENVIRONMENT` | String | No | `sandbox` (dev) / `production` (prod) | Must be "sandbox" or "production" |
+
+## Notes
+
+- Uses `app-store-server-library-swift` v2.x (not v4.0.0) due to jwt-kit 4.x compatibility — the project uses jwt v4.x, and library v4.0.0 requires jwt-kit 5.x
+- The `MockAppStoreValidationService` in the test file is designed for reuse in Story 2.4 controller tests
+- Bundle ID and environment validation are handled internally by `SignedDataVerifier` — no need for manual checks
+- The service is initialized eagerly at app startup; configuration errors surface immediately


### PR DESCRIPTION
## Summary

Implement server-side App Store signed transaction (JWS) validation using Apple's `app-store-server-library-swift`, enabling secure verification of iOS in-app purchases before crediting users.

## Changes

- Added `app-store-server-library-swift` v2.x dependency to `Package.swift`
- Created `AppleConfig` struct with 6 environment variables (`APPLE_ISSUER_ID`, `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY`, `APP_BUNDLE_ID`, `APP_APPLE_ID`, `APPLE_ENVIRONMENT`) across all configuration environments
- Created `AppStoreValidationService` protocol with `verify(signedTransaction:)` method
- Implemented `DefaultAppStoreValidationService` using Apple's `SignedDataVerifier` with embedded Root CA G3 certificate
- Defined `AppStoreValidationResult` and `AppStoreValidationError` types
- Registered service in dependency injection (`Application+Services.swift`, `Request+Services.swift`, `Application-Setup.swift`)
- Added startup validation of Apple config in production
- Added 12 unit tests covering result fields, error equatability, invalid JWS rejection, and mock service behavior
- Added feature documentation: `docs/features/app-store-validation.md`
- Updated conditional docs guide with discoverability conditions

## Testing

- 12 unit tests pass covering validation result fields, error type distinctness, invalid/empty/tampered JWS rejection, and mock service protocol testability
- Code review passed after 2 review cycles (environment field requirement, error mapping fixes, config validation added)
- Full regression suite passes (4 test suites, all green)

## Evidence

- `code_review_passed = true` — all findings fixed across 2 adversarial review cycles
- `tests_passed = true` — 12 unit tests, full regression green
- `lint_passed = true`


---
Linear: https://linear.app/rule/issue/RULE-252