### PR TITLE
RULE-253: Story 2.3: Implement Play Store Receipt Validation

### DIFF
--- a/Sources/App/Common/Extensions/Application+Services.swift
+++ b/Sources/App/Common/Extensions/Application+Services.swift
@@ -22,6 +22,7 @@ final class ServiceStorageContainer: @unchecked Sendable {
     var aiResponseValidatorService: AIResponseValidationService?
     var remoteConfigCacheService: RemoteConfigCacheService?
     var appStoreValidationService: AppStoreValidationService?
+    var playStoreValidationService: PlayStoreValidationService?
 
     // MARK: - Repositories
 
@@ -122,6 +123,11 @@ extension Application {
     var appStoreValidationService: AppStoreValidationService {
         get { serviceStorage.appStoreValidationService! }
         set { serviceStorage.appStoreValidationService = newValue }
+    }
+
+    var playStoreValidationService: PlayStoreValidationService {
+        get { serviceStorage.playStoreValidationService! }
+        set { serviceStorage.playStoreValidationService = newValue }
     }
 
     // MARK: - Repositories

--- a/Sources/App/Entrypoint/Application-Setup.swift
+++ b/Sources/App/Entrypoint/Application-Setup.swift
@@ -210,6 +210,7 @@ extension Application {
     emailService = BrevoClient(app: self)
     llmService = GoogleGeminiService(app: self)
     appStoreValidationService = DefaultAppStoreValidationService(app: self)
+    playStoreValidationService = DefaultPlayStoreValidationService(app: self)
 
     // Initialize Redis-based services
     let redisConfig = try configuration.redis

--- a/Sources/App/Modules/Receipts/Services/PlayStoreValidationService.swift
+++ b/Sources/App/Modules/Receipts/Services/PlayStoreValidationService.swift
@@ -220,7 +220,13 @@ final class DefaultPlayStoreValidationService: PlayStoreValidationService, @unch
         )
 
         // Sign JWT with RS256 using the service account private key
-        let privateKeyData = config.privateKey.data(using: .utf8) ?? Data()
+        // Normalize escaped newlines from environment variables (\\n → \n)
+        let normalizedKey = config.privateKey.replacingOccurrences(of: "\\n", with: "\n")
+        guard let privateKeyData = normalizedKey.data(using: .utf8), !privateKeyData.isEmpty else {
+            throw PlayStoreValidationError.configurationError(
+                "Google service account private key is empty or contains invalid characters"
+            )
+        }
         let signers = JWTSigners()
         do {
             try signers.use(.rs256(key: .private(pem: privateKeyData)))
@@ -260,7 +266,7 @@ final class DefaultPlayStoreValidationService: PlayStoreValidationService, @unch
         // Cache the token with a 5-minute safety margin
         tokenLock.withLock {
             cachedToken = tokenResponse.accessToken
-            tokenExpiry = Date().addingTimeInterval(Double(tokenResponse.expiresIn - 300))
+            tokenExpiry = Date().addingTimeInterval(Double(max(0, tokenResponse.expiresIn - 300)))
         }
 
         return tokenResponse.accessToken
@@ -273,7 +279,11 @@ final class DefaultPlayStoreValidationService: PlayStoreValidationService, @unch
         purchaseToken: String,
         accessToken: String
     ) async throws -> PlayStoreValidationResult {
-        let url = "\(Self.playAPIBase)/\(packageName)/purchases/products/\(productId)/tokens/\(purchaseToken)"
+        guard let encodedProductId = productId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let encodedToken = purchaseToken.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            throw PlayStoreValidationError.invalidToken
+        }
+        let url = "\(Self.playAPIBase)/\(packageName)/purchases/products/\(encodedProductId)/tokens/\(encodedToken)"
 
         let response = try await app.client.get(URI(string: url)) { req in
             req.headers.bearerAuthorization = BearerAuthorization(token: accessToken)
@@ -307,7 +317,10 @@ final class DefaultPlayStoreValidationService: PlayStoreValidationService, @unch
         let purchase = try response.content.decode(GooglePlayPurchaseResponse.self)
 
         // Validate purchase state (0 = Purchased)
-        if let purchaseState = purchase.purchaseState, purchaseState != 0 {
+        guard let purchaseState = purchase.purchaseState else {
+            throw PlayStoreValidationError.verificationFailed("Missing purchaseState in purchase response")
+        }
+        guard purchaseState == 0 else {
             throw PlayStoreValidationError.verificationFailed(
                 "Purchase is not in a valid state (state: \(purchaseState))"
             )

--- a/Sources/App/Modules/Receipts/Services/PlayStoreValidationService.swift
+++ b/Sources/App/Modules/Receipts/Services/PlayStoreValidationService.swift
@@ -1,0 +1,338 @@
+import Foundation
+@preconcurrency import JWTKit
+import NIOConcurrencyHelpers
+import Vapor
+
+// MARK: - Validation Result
+
+/// Result of a successful Play Store purchase verification.
+struct PlayStoreValidationResult: Sendable {
+    /// The unique order ID from Google Play (acts as transaction identifier).
+    let transactionId: String
+
+    /// The product identifier (SKU) of the purchased item.
+    let productId: String
+
+    /// The date when the purchase was made.
+    let purchaseDate: Date
+}
+
+// MARK: - Validation Errors
+
+/// Errors that can occur during Play Store receipt validation.
+enum PlayStoreValidationError: Error, Equatable {
+    /// The purchase token is invalid or malformed.
+    case invalidToken
+
+    /// The purchase was not found (product/token combination doesn't exist).
+    case purchaseNotFound
+
+    /// The service is not properly configured (missing credentials).
+    case configurationError(String)
+
+    /// A general verification failure with a descriptive reason.
+    case verificationFailed(String)
+
+    /// The Google API returned an unexpected error.
+    case apiError(Int, String)
+
+    static func == (lhs: PlayStoreValidationError, rhs: PlayStoreValidationError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidToken, .invalidToken):
+            return true
+        case (.purchaseNotFound, .purchaseNotFound):
+            return true
+        case (.configurationError(let a), .configurationError(let b)):
+            return a == b
+        case (.verificationFailed(let a), .verificationFailed(let b)):
+            return a == b
+        case (.apiError(let c1, let m1), .apiError(let c2, let m2)):
+            return c1 == c2 && m1 == m2
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - Protocol
+
+/// Service responsible for verifying Google Play Store purchases.
+///
+/// This service validates purchase tokens by calling the Google Play Developer API
+/// using OAuth2 service account authentication.
+protocol PlayStoreValidationService: Sendable {
+    /// Verifies a Play Store purchase.
+    ///
+    /// - Parameters:
+    ///   - productId: The product identifier (SKU) of the purchased item.
+    ///   - purchaseToken: The purchase token received from the client.
+    /// - Returns: The validated purchase details.
+    /// - Throws: ``PlayStoreValidationError`` if verification fails.
+    func verify(productId: String, purchaseToken: String) async throws -> PlayStoreValidationResult
+}
+
+// MARK: - Google OAuth2 JWT Claims
+
+/// JWT claims for Google service account OAuth2 token exchange.
+struct GoogleServiceAccountClaims: JWTPayload {
+    /// The email address of the service account.
+    var iss: IssuerClaim
+
+    /// The required OAuth2 scope.
+    var scope: String
+
+    /// The token endpoint URL.
+    var aud: AudienceClaim
+
+    /// Token issued at time.
+    var iat: IssuedAtClaim
+
+    /// Token expiration time.
+    var exp: ExpirationClaim
+
+    func verify(using signer: JWTSigner) throws {
+        try exp.verifyNotExpired()
+    }
+}
+
+// MARK: - Google API Response Types
+
+/// Response from Google OAuth2 token endpoint.
+struct GoogleTokenResponse: Content {
+    let accessToken: String
+    let tokenType: String
+    let expiresIn: Int
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+    }
+}
+
+/// Response from Google Play Developer API purchases.products.get endpoint.
+struct GooglePlayPurchaseResponse: Content {
+    /// 0 = Purchased, 1 = Canceled, 2 = Pending
+    let purchaseState: Int?
+
+    /// 0 = Yet to be acknowledged, 1 = Acknowledged
+    let acknowledgementState: Int?
+
+    /// The order ID of the purchase.
+    let orderId: String?
+
+    /// Time the product was purchased, in milliseconds since the epoch.
+    let purchaseTimeMillis: String?
+
+    /// The consumption state of the inapp product. 0 = Yet to be consumed, 1 = Consumed.
+    let consumptionState: Int?
+}
+
+/// Error response from Google APIs.
+struct GoogleAPIErrorResponse: Content {
+    let error: GoogleAPIError?
+
+    struct GoogleAPIError: Content {
+        let code: Int?
+        let message: String?
+    }
+}
+
+// MARK: - Implementation
+
+/// Default implementation of ``PlayStoreValidationService`` using Google Play Developer API.
+///
+/// Uses OAuth2 service account JWT flow to authenticate with Google APIs,
+/// then calls `purchases.products.get` to verify one-time purchases.
+/// Access tokens are cached for their lifetime (typically 1 hour).
+final class DefaultPlayStoreValidationService: PlayStoreValidationService, @unchecked Sendable {
+    let app: Application
+
+    /// Cached OAuth2 access token and its expiry time.
+    private var cachedToken: String?
+    private var tokenExpiry: Date?
+
+    /// Lock for thread-safe token cache access.
+    private let tokenLock = NIOLock()
+
+    private static let tokenEndpoint = "https://oauth2.googleapis.com/token"
+    private static let playAPIBase = "https://androidpublisher.googleapis.com/androidpublisher/v3/applications"
+    private static let scope = "https://www.googleapis.com/auth/androidpublisher"
+
+    init(app: Application) {
+        self.app = app
+    }
+
+    func verify(productId: String, purchaseToken: String) async throws -> PlayStoreValidationResult {
+        guard !purchaseToken.isEmpty else {
+            throw PlayStoreValidationError.invalidToken
+        }
+
+        guard !productId.isEmpty else {
+            throw PlayStoreValidationError.verificationFailed("Product ID cannot be empty")
+        }
+
+        let config: GooglePlayConfig
+        do {
+            config = try app.configuration.google
+        } catch {
+            throw PlayStoreValidationError.configurationError(
+                "Failed to load Google Play configuration: \(error)"
+            )
+        }
+
+        let accessToken = try await getAccessToken(config: config)
+        return try await verifyPurchase(
+            packageName: config.packageName,
+            productId: productId,
+            purchaseToken: purchaseToken,
+            accessToken: accessToken
+        )
+    }
+
+    // MARK: - Private
+
+    /// Retrieves a valid access token, using the cache if available.
+    private func getAccessToken(config: GooglePlayConfig) async throws -> String {
+        // Check cache first
+        let (cached, expiry) = tokenLock.withLock {
+            (cachedToken, tokenExpiry)
+        }
+
+        if let cached, let expiry, Date() < expiry {
+            return cached
+        }
+
+        // Generate new token
+        let token = try await requestAccessToken(config: config)
+        return token
+    }
+
+    /// Generates a JWT and exchanges it for an OAuth2 access token.
+    private func requestAccessToken(config: GooglePlayConfig) async throws -> String {
+        let now = Date()
+        let claims = GoogleServiceAccountClaims(
+            iss: IssuerClaim(value: config.serviceAccountEmail),
+            scope: Self.scope,
+            aud: AudienceClaim(value: Self.tokenEndpoint),
+            iat: IssuedAtClaim(value: now),
+            exp: ExpirationClaim(value: now.addingTimeInterval(3600))
+        )
+
+        // Sign JWT with RS256 using the service account private key
+        let privateKeyData = config.privateKey.data(using: .utf8) ?? Data()
+        let signers = JWTSigners()
+        do {
+            try signers.use(.rs256(key: .private(pem: privateKeyData)))
+        } catch {
+            throw PlayStoreValidationError.configurationError(
+                "Failed to load Google service account private key: \(error)"
+            )
+        }
+
+        let jwt: String
+        do {
+            jwt = try signers.sign(claims)
+        } catch {
+            throw PlayStoreValidationError.configurationError(
+                "Failed to sign JWT for Google OAuth2: \(error)"
+            )
+        }
+
+        // Exchange JWT for access token
+        let response = try await app.client.post(URI(string: Self.tokenEndpoint)) { req in
+            try req.content.encode([
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "assertion": jwt,
+            ], as: .urlEncodedForm)
+        }
+
+        guard response.status == .ok else {
+            let errorBody = try? response.content.decode(GoogleAPIErrorResponse.self)
+            let message = errorBody?.error?.message ?? "HTTP \(response.status.code)"
+            throw PlayStoreValidationError.configurationError(
+                "Failed to obtain access token from Google: \(message)"
+            )
+        }
+
+        let tokenResponse = try response.content.decode(GoogleTokenResponse.self)
+
+        // Cache the token with a 5-minute safety margin
+        tokenLock.withLock {
+            cachedToken = tokenResponse.accessToken
+            tokenExpiry = Date().addingTimeInterval(Double(tokenResponse.expiresIn - 300))
+        }
+
+        return tokenResponse.accessToken
+    }
+
+    /// Calls Google Play Developer API to verify the purchase.
+    private func verifyPurchase(
+        packageName: String,
+        productId: String,
+        purchaseToken: String,
+        accessToken: String
+    ) async throws -> PlayStoreValidationResult {
+        let url = "\(Self.playAPIBase)/\(packageName)/purchases/products/\(productId)/tokens/\(purchaseToken)"
+
+        let response = try await app.client.get(URI(string: url)) { req in
+            req.headers.bearerAuthorization = BearerAuthorization(token: accessToken)
+        }
+
+        switch response.status {
+        case .ok:
+            break
+        case .notFound:
+            throw PlayStoreValidationError.purchaseNotFound
+        case .unauthorized:
+            // Invalidate cached token on 401
+            tokenLock.withLock {
+                cachedToken = nil
+                tokenExpiry = nil
+            }
+            throw PlayStoreValidationError.verificationFailed(
+                "Google API authentication failed — token may have expired"
+            )
+        case .badRequest:
+            throw PlayStoreValidationError.invalidToken
+        default:
+            let errorBody = try? response.content.decode(GoogleAPIErrorResponse.self)
+            let message = errorBody?.error?.message ?? "Unknown error"
+            throw PlayStoreValidationError.apiError(
+                Int(response.status.code),
+                message
+            )
+        }
+
+        let purchase = try response.content.decode(GooglePlayPurchaseResponse.self)
+
+        // Validate purchase state (0 = Purchased)
+        if let purchaseState = purchase.purchaseState, purchaseState != 0 {
+            throw PlayStoreValidationError.verificationFailed(
+                "Purchase is not in a valid state (state: \(purchaseState))"
+            )
+        }
+
+        guard let orderId = purchase.orderId else {
+            throw PlayStoreValidationError.verificationFailed("Missing orderId in purchase response")
+        }
+
+        let purchaseDate: Date
+        if let millis = purchase.purchaseTimeMillis, let millisValue = Double(millis) {
+            purchaseDate = Date(timeIntervalSince1970: millisValue / 1000.0)
+        } else {
+            purchaseDate = Date()
+        }
+
+        app.logger.info("Play Store purchase verified successfully", metadata: [
+            "orderId": .string(orderId),
+            "productId": .string(productId),
+        ])
+
+        return PlayStoreValidationResult(
+            transactionId: orderId,
+            productId: productId,
+            purchaseDate: purchaseDate
+        )
+    }
+}

--- a/Sources/App/Services/Configuration/ConfigurationService.swift
+++ b/Sources/App/Services/Configuration/ConfigurationService.swift
@@ -99,6 +99,17 @@ protocol ConfigurationService: Sendable {
   /// - Throws: ``ConfigurationError`` if Apple settings are missing or invalid
   var apple: AppleConfig { get throws }
 
+  /// Google Play Store configuration for receipt validation.
+  ///
+  /// Contains credentials for:
+  /// - Google Play Developer API authentication via service account
+  /// - OAuth2 JWT token generation
+  /// - Purchase verification
+  ///
+  /// - Returns: Google Play configuration with service account credentials
+  /// - Throws: ``ConfigurationError`` if Google Play settings are missing or invalid
+  var google: GooglePlayConfig { get throws }
+
   /// Validates all configuration settings for the current environment.
   ///
   /// Performs comprehensive validation of:

--- a/Sources/App/Services/Configuration/ConfigurationTypes.swift
+++ b/Sources/App/Services/Configuration/ConfigurationTypes.swift
@@ -290,3 +290,18 @@ struct AppleConfig: Sendable {
     /// The App Store environment: "sandbox" or "production".
     let environment: String
 }
+
+/// Google Play Store configuration for In-App Purchase receipt validation.
+///
+/// Contains credentials and settings required to verify Play Store purchases
+/// using Google Play Developer API with service account OAuth2 authentication.
+struct GooglePlayConfig: Sendable {
+    /// The service account email address from Google Cloud Console.
+    let serviceAccountEmail: String
+
+    /// The private key content (PEM format) from the service account JSON key file.
+    let privateKey: String
+
+    /// The Android application package name (e.g., "com.yourcompany.app").
+    let packageName: String
+}

--- a/Sources/App/Services/Configuration/DevelopmentConfiguration.swift
+++ b/Sources/App/Services/Configuration/DevelopmentConfiguration.swift
@@ -103,6 +103,16 @@ struct DevelopmentConfiguration: ConfigurationService {
     }
   }
 
+  var google: GooglePlayConfig {
+    get throws {
+      GooglePlayConfig(
+        serviceAccountEmail: Environment.get("GOOGLE_SERVICE_ACCOUNT_EMAIL") ?? "dev@dev-project.iam.gserviceaccount.com",
+        privateKey: Environment.get("GOOGLE_PRIVATE_KEY") ?? "dev_private_key",
+        packageName: Environment.get("GOOGLE_PACKAGE_NAME") ?? "com.dev.app"
+      )
+    }
+  }
+
   func validate() throws {
     let db = try database
 

--- a/Sources/App/Services/Configuration/ProductionConfiguration.swift
+++ b/Sources/App/Services/Configuration/ProductionConfiguration.swift
@@ -316,6 +316,37 @@ struct ProductionConfiguration: ConfigurationService {
     }
   }
 
+  var google: GooglePlayConfig {
+    get throws {
+      guard let serviceAccountEmail = Environment.get("GOOGLE_SERVICE_ACCOUNT_EMAIL") else {
+        throw ConfigurationError.missingRequired(
+          key: "GOOGLE_SERVICE_ACCOUNT_EMAIL",
+          suggestion: "Set GOOGLE_SERVICE_ACCOUNT_EMAIL environment variable from Google Cloud service account"
+        )
+      }
+
+      guard let privateKey = Environment.get("GOOGLE_PRIVATE_KEY") else {
+        throw ConfigurationError.missingRequired(
+          key: "GOOGLE_PRIVATE_KEY",
+          suggestion: "Set GOOGLE_PRIVATE_KEY environment variable with the PEM private key from service account JSON"
+        )
+      }
+
+      guard let packageName = Environment.get("GOOGLE_PACKAGE_NAME") else {
+        throw ConfigurationError.missingRequired(
+          key: "GOOGLE_PACKAGE_NAME",
+          suggestion: "Set GOOGLE_PACKAGE_NAME environment variable (e.g., com.yourcompany.app)"
+        )
+      }
+
+      return GooglePlayConfig(
+        serviceAccountEmail: serviceAccountEmail,
+        privateKey: privateKey,
+        packageName: packageName
+      )
+    }
+  }
+
   func validate() throws {
     let db = try database
     let services = try services
@@ -324,6 +355,7 @@ struct ProductionConfiguration: ConfigurationService {
     _ = try aws
     _ = try apns
     _ = try apple
+    _ = try google
 
     // Database validation
     if db.port < 1 || db.port > 65535 {

--- a/Sources/App/Services/Configuration/TestingConfiguration.swift
+++ b/Sources/App/Services/Configuration/TestingConfiguration.swift
@@ -97,6 +97,16 @@ struct TestingConfiguration: ConfigurationService {
     }
   }
 
+  var google: GooglePlayConfig {
+    get throws {
+      GooglePlayConfig(
+        serviceAccountEmail: "test@test-project.iam.gserviceaccount.com",
+        privateKey: "test_private_key",
+        packageName: "com.test.app"
+      )
+    }
+  }
+
   func validate() throws {
     // Minimal validation for tests - all values are hardcoded and valid
   }

--- a/Tests/AppTests/Services/Receipts/PlayStoreValidationServiceTests.swift
+++ b/Tests/AppTests/Services/Receipts/PlayStoreValidationServiceTests.swift
@@ -1,0 +1,237 @@
+@testable import App
+import Testing
+import VaporTesting
+
+@Suite(.serialized)
+struct PlayStoreValidationServiceTests {
+
+    // MARK: - PlayStoreValidationResult Tests
+
+    @Test("Validation result captures all required fields", .tags(.unit))
+    func validationResultFields() {
+        let date = Date(timeIntervalSince1970: 1700000000)
+        let result = PlayStoreValidationResult(
+            transactionId: "GPA.1234-5678-9012-34567",
+            productId: "com.app.credits.100",
+            purchaseDate: date
+        )
+
+        #expect(result.transactionId == "GPA.1234-5678-9012-34567")
+        #expect(result.productId == "com.app.credits.100")
+        #expect(result.purchaseDate == date)
+    }
+
+    // MARK: - PlayStoreValidationError Tests
+
+    @Test("Error cases are equatable", .tags(.unit))
+    func errorEquatable() {
+        #expect(PlayStoreValidationError.invalidToken == PlayStoreValidationError.invalidToken)
+        #expect(PlayStoreValidationError.purchaseNotFound == PlayStoreValidationError.purchaseNotFound)
+        #expect(PlayStoreValidationError.configurationError("a") == PlayStoreValidationError.configurationError("a"))
+        #expect(PlayStoreValidationError.configurationError("a") != PlayStoreValidationError.configurationError("b"))
+        #expect(PlayStoreValidationError.verificationFailed("x") == PlayStoreValidationError.verificationFailed("x"))
+        #expect(PlayStoreValidationError.apiError(500, "err") == PlayStoreValidationError.apiError(500, "err"))
+        #expect(PlayStoreValidationError.apiError(500, "a") != PlayStoreValidationError.apiError(500, "b"))
+        #expect(PlayStoreValidationError.invalidToken != PlayStoreValidationError.purchaseNotFound)
+    }
+
+    @Test("All error cases are distinct", .tags(.unit))
+    func errorCasesDistinct() {
+        let cases: [PlayStoreValidationError] = [
+            .invalidToken,
+            .purchaseNotFound,
+            .configurationError("test"),
+            .verificationFailed("test"),
+            .apiError(500, "test"),
+        ]
+
+        for i in 0..<cases.count {
+            for j in (i + 1)..<cases.count {
+                #expect(cases[i] != cases[j], "Expected \(cases[i]) != \(cases[j])")
+            }
+        }
+    }
+
+    @Test("Error conforms to Error protocol", .tags(.unit))
+    func errorConformsToError() {
+        let error: Error = PlayStoreValidationError.invalidToken
+        #expect(error is PlayStoreValidationError)
+    }
+
+    // MARK: - DefaultPlayStoreValidationService Tests
+
+    @Test("Service rejects empty purchase token", .tags(.unit))
+    func rejectEmptyToken() async throws {
+        let app = try await Application.make(.testing)
+        try app.initializeConfiguration()
+
+        let service = DefaultPlayStoreValidationService(app: app)
+
+        do {
+            _ = try await service.verify(productId: "com.app.product", purchaseToken: "")
+            Issue.record("Expected PlayStoreValidationError to be thrown")
+        } catch let error as PlayStoreValidationError {
+            #expect(error == .invalidToken)
+        }
+
+        try await app.asyncShutdown()
+    }
+
+    @Test("Service rejects empty product ID", .tags(.unit))
+    func rejectEmptyProductId() async throws {
+        let app = try await Application.make(.testing)
+        try app.initializeConfiguration()
+
+        let service = DefaultPlayStoreValidationService(app: app)
+
+        do {
+            _ = try await service.verify(productId: "", purchaseToken: "some-token")
+            Issue.record("Expected PlayStoreValidationError to be thrown")
+        } catch let error as PlayStoreValidationError {
+            #expect(error == .verificationFailed("Product ID cannot be empty"))
+        }
+
+        try await app.asyncShutdown()
+    }
+
+    // MARK: - Mock Service Tests (protocol testability)
+
+    @Test("Mock service can return success result", .tags(.unit))
+    func mockServiceSuccess() async throws {
+        let mockService = MockPlayStoreValidationService()
+        let date = Date()
+        mockService.resultToReturn = PlayStoreValidationResult(
+            transactionId: "GPA.1234-5678",
+            productId: "com.app.product",
+            purchaseDate: date
+        )
+
+        let result = try await mockService.verify(productId: "com.app.product", purchaseToken: "test-token")
+        #expect(result.transactionId == "GPA.1234-5678")
+        #expect(result.productId == "com.app.product")
+        #expect(result.purchaseDate == date)
+        #expect(mockService.verifyCallCount == 1)
+        #expect(mockService.lastProductId == "com.app.product")
+        #expect(mockService.lastPurchaseToken == "test-token")
+    }
+
+    @Test("Mock service can throw invalidToken error", .tags(.unit))
+    func mockServiceInvalidToken() async throws {
+        let mockService = MockPlayStoreValidationService()
+        mockService.errorToThrow = .invalidToken
+
+        do {
+            _ = try await mockService.verify(productId: "any", purchaseToken: "any")
+            Issue.record("Expected error to be thrown")
+        } catch let error as PlayStoreValidationError {
+            #expect(error == .invalidToken)
+        }
+        #expect(mockService.verifyCallCount == 1)
+    }
+
+    @Test("Mock service can throw purchaseNotFound error", .tags(.unit))
+    func mockServicePurchaseNotFound() async throws {
+        let mockService = MockPlayStoreValidationService()
+        mockService.errorToThrow = .purchaseNotFound
+
+        do {
+            _ = try await mockService.verify(productId: "prod", purchaseToken: "token")
+            Issue.record("Expected error to be thrown")
+        } catch let error as PlayStoreValidationError {
+            #expect(error == .purchaseNotFound)
+        }
+    }
+
+    @Test("Mock service tracks call count correctly", .tags(.unit))
+    func mockServiceCallTracking() async throws {
+        let mockService = MockPlayStoreValidationService()
+        mockService.resultToReturn = PlayStoreValidationResult(
+            transactionId: "t1", productId: "p1", purchaseDate: Date()
+        )
+
+        _ = try await mockService.verify(productId: "p1", purchaseToken: "first")
+        _ = try await mockService.verify(productId: "p2", purchaseToken: "second")
+        _ = try await mockService.verify(productId: "p3", purchaseToken: "third")
+
+        #expect(mockService.verifyCallCount == 3)
+        #expect(mockService.lastProductId == "p3")
+        #expect(mockService.lastPurchaseToken == "third")
+    }
+
+    @Test("Mock service reset clears state", .tags(.unit))
+    func mockServiceReset() async throws {
+        let mockService = MockPlayStoreValidationService()
+        mockService.resultToReturn = PlayStoreValidationResult(
+            transactionId: "t1", productId: "p1", purchaseDate: Date()
+        )
+        _ = try await mockService.verify(productId: "p1", purchaseToken: "test")
+
+        mockService.reset()
+
+        #expect(mockService.verifyCallCount == 0)
+        #expect(mockService.lastProductId == nil)
+        #expect(mockService.lastPurchaseToken == nil)
+        #expect(mockService.resultToReturn == nil)
+        #expect(mockService.errorToThrow == nil)
+    }
+
+    // MARK: - GooglePlayConfig Tests
+
+    @Test("GooglePlayConfig captures all fields", .tags(.unit))
+    func googlePlayConfigFields() {
+        let config = GooglePlayConfig(
+            serviceAccountEmail: "test@project.iam.gserviceaccount.com",
+            privateKey: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----",
+            packageName: "com.example.app"
+        )
+
+        #expect(config.serviceAccountEmail == "test@project.iam.gserviceaccount.com")
+        #expect(config.privateKey.contains("RSA PRIVATE KEY"))
+        #expect(config.packageName == "com.example.app")
+    }
+
+    @Test("Testing configuration provides Google Play config", .tags(.unit))
+    func testingConfigProvidesGoogleConfig() throws {
+        let config = TestingConfiguration()
+        let google = try config.google
+        #expect(!google.serviceAccountEmail.isEmpty)
+        #expect(!google.privateKey.isEmpty)
+        #expect(!google.packageName.isEmpty)
+    }
+}
+
+// MARK: - Mock Implementation
+
+/// Mock implementation of PlayStoreValidationService for testing.
+/// Demonstrates the protocol can be mocked for controller tests in later stories.
+final class MockPlayStoreValidationService: PlayStoreValidationService, @unchecked Sendable {
+    var resultToReturn: PlayStoreValidationResult?
+    var errorToThrow: PlayStoreValidationError?
+    var verifyCallCount = 0
+    var lastProductId: String?
+    var lastPurchaseToken: String?
+
+    func verify(productId: String, purchaseToken: String) async throws -> PlayStoreValidationResult {
+        verifyCallCount += 1
+        lastProductId = productId
+        lastPurchaseToken = purchaseToken
+
+        if let error = errorToThrow {
+            throw error
+        }
+
+        guard let result = resultToReturn else {
+            throw PlayStoreValidationError.configurationError("Mock not configured")
+        }
+
+        return result
+    }
+
+    func reset() {
+        resultToReturn = nil
+        errorToThrow = nil
+        verifyCallCount = 0
+        lastProductId = nil
+        lastPurchaseToken = nil
+    }
+}

--- a/docs/CONDITIONAL_DOCS.md
+++ b/docs/CONDITIONAL_DOCS.md
@@ -170,3 +170,11 @@ This guide helps you find relevant documentation based on what you're working on
     - When adding new platform-specific purchase verification services
     - When troubleshooting App Store JWS signature verification failures
     - When upgrading the app-store-server-library-swift dependency
+
+- docs/features/play-store-validation.md
+  - Conditions:
+    - When implementing Play Store purchase verification in the Receipts module
+    - When configuring Google Play service account credentials or environment variables
+    - When adding new platform-specific purchase verification services for Android
+    - When troubleshooting Google OAuth2 service account authentication issues
+    - When working with Google Play Developer API token exchange flow

--- a/docs/features/play-store-validation.md
+++ b/docs/features/play-store-validation.md
@@ -1,0 +1,90 @@
+# Play Store Purchase Validation
+
+**Date:** 2026-03-14
+**Related Files:** `Sources/App/Modules/Receipts/Services/PlayStoreValidationService.swift`, `Sources/App/Services/Configuration/ConfigurationTypes.swift`
+
+## Overview
+
+Server-side verification of Google Play Store one-time purchases using the Google Play Developer API. The service authenticates via OAuth2 service account JWT flow, exchanges the JWT for an access token, then calls `purchases.products.get` to validate purchase tokens submitted by Android clients.
+
+## What Was Built
+
+- `PlayStoreValidationService` protocol for purchase verification
+- `DefaultPlayStoreValidationService` implementation with OAuth2 JWT authentication
+- `PlayStoreValidationResult` struct capturing transaction details (order ID, product ID, purchase date)
+- `PlayStoreValidationError` enum with specific failure cases (invalidToken, purchaseNotFound, configurationError, verificationFailed, apiError)
+- `GooglePlayConfig` configuration type with 3 environment variables
+- `MockPlayStoreValidationService` for use in controller tests (Story 2.4)
+- OAuth2 access token caching with thread-safe `NIOLock` and 5-minute expiry safety margin
+
+## Technical Implementation
+
+### Key Files
+
+- `Sources/App/Modules/Receipts/Services/PlayStoreValidationService.swift`: Protocol, result/error types, JWT claims, Google API response types, and default implementation
+- `Sources/App/Services/Configuration/ConfigurationTypes.swift`: `GooglePlayConfig` struct definition
+- `Sources/App/Services/Configuration/ProductionConfiguration.swift`: Production env var loading
+- `Sources/App/Common/Extensions/Application+Services.swift`: Service registration in DI container
+- `Sources/App/Entrypoint/Application-Setup.swift`: Service initialization at startup
+- `Tests/AppTests/Services/Receipts/PlayStoreValidationServiceTests.swift`: Unit tests with mock service
+
+### Key Patterns
+
+- **OAuth2 Service Account JWT Flow**: The service generates a JWT signed with RS256 using the service account private key, exchanges it at Google's token endpoint for an access token, then uses that token as a Bearer header for API calls. This is the standard Google service account authentication pattern — no user interaction required.
+
+- **Token Caching with Safety Margin**: Access tokens are cached with `NIOLock` for thread safety. The cached token's expiry is set to `expiresIn - 300` seconds (5-minute safety margin) to prevent using tokens that are about to expire during in-flight requests.
+
+- **PEM Key Newline Normalization**: Environment variables often store PEM keys with literal `\n` instead of actual newlines. The service normalizes `\\n` → `\n` before parsing, which is critical for keys loaded from `.env` files or container orchestration secrets.
+
+- **Purchase State Validation**: The Google Play API response includes a `purchaseState` field (0=Purchased, 1=Canceled, 2=Pending). The service explicitly validates that `purchaseState == 0` before accepting a purchase, rejecting canceled or pending purchases.
+
+- **URL Encoding for API Path Parameters**: Product IDs and purchase tokens are percent-encoded before being interpolated into the API URL path to prevent injection and handle special characters.
+
+### Code Examples
+
+**Verifying a Play Store purchase (in a controller):**
+```swift
+let result = try await req.application.playStoreValidationService.verify(
+    productId: requestBody.productId,
+    purchaseToken: requestBody.purchaseToken
+)
+// result.transactionId = Google Play order ID
+// result.productId = SKU
+// result.purchaseDate = purchase timestamp
+```
+
+**Using the mock in tests:**
+```swift
+let mock = MockPlayStoreValidationService()
+mock.resultToReturn = PlayStoreValidationResult(
+    transactionId: "GPA.1234-5678",
+    productId: "com.app.credits.100",
+    purchaseDate: Date()
+)
+// Inject mock into test context
+```
+
+## How to Use
+
+1. Set the required environment variables (see Configuration below)
+2. The service is registered automatically in `Application-Setup.swift`
+3. Access via `req.application.playStoreValidationService` in any controller
+4. Pass the client's product ID and purchase token to `verify(productId:purchaseToken:)`
+5. Handle `PlayStoreValidationError` for invalid/tampered purchases
+
+## Configuration
+
+| Variable | Type | Required | Default (Dev) | Description |
+|----------|------|----------|---------------|-------------|
+| `GOOGLE_SERVICE_ACCOUNT_EMAIL` | String | Production | `test@project.iam.gserviceaccount.com` | Service account email from Google Cloud Console |
+| `GOOGLE_PRIVATE_KEY` | String | Production | Test RSA key | PEM-format private key from service account JSON |
+| `GOOGLE_PACKAGE_NAME` | String | Production | `com.test.app` | Android application package name |
+
+## Notes
+
+- Uses `JWTKit` (already a project dependency via Vapor's JWT package) for RS256 JWT signing — no new dependencies required
+- The service account must have "View financial data" permission in Google Play Console
+- Token cache invalidation happens automatically on 401 responses, triggering re-authentication on the next call
+- The `MockPlayStoreValidationService` in the test file is designed for reuse in Story 2.4 controller tests
+- Mirrors the `AppStoreValidationService` pattern for consistency across platforms
+- `TransactionPlatform.android` already exists in the database model from the Receipts module foundation (Story 2.1)


### PR DESCRIPTION
## Summary

Implements server-side Google Play Store purchase validation for Android in-app purchases, completing Story 2.3 of Epic 2 (In-App Purchase Verification). The service authenticates via OAuth2 service account JWT flow and calls the Google Play Developer API to verify one-time purchases.

## Changes

- Added `PlayStoreValidationService` protocol and `DefaultPlayStoreValidationService` implementation with OAuth2 JWT authentication, token caching, and Google Play Developer API integration
- Added `GooglePlayConfig` struct to the configuration system with service account credentials across all environments (Testing, Development, Production)
- Added `google` property to `ConfigurationService` protocol and all implementations
- Registered `PlayStoreValidationService` in DI container (`Application+Services.swift`) and service initialization (`Application-Setup.swift`)
- Added 13 unit tests covering validation result fields, error equatability, input validation, mock service behavior, and configuration
- Applied review fixes: URL encoding for API path parameters, purchaseState validation, PEM private key newline normalization
- Added feature documentation: `docs/features/play-store-validation.md`
- Updated conditional docs guide with discoverability conditions

## Testing

- 13 new unit tests all passing
- Full regression suite (69 tests) passes
- Tests cover: result struct fields, error enum equatability/distinctness, empty token/product ID rejection, mock service success/error/tracking/reset, GooglePlayConfig fields, testing configuration validation
- Review cycle validated: URL encoding prevents path injection, purchaseState checked for canceled/pending purchases, private key newline normalization handles env var escaping

## Evidence

- Validation phase confirmed all tests pass and build succeeds
- Review cycle 1 identified and fixed 3 issues (URL encoding, purchaseState validation, private key normalization) — all verified as resolved


---
Linear: https://linear.app/rule/issue/RULE-253