### PR TITLE
RULE-137: Story 2.4: Create Receipt Validation Endpoint

### DIFF
--- a/Sources/App/Common/Extensions/Request+Services.swift
+++ b/Sources/App/Common/Extensions/Request+Services.swift
@@ -68,4 +68,8 @@ struct RequestServices: @unchecked Sendable {
     var appStoreValidation: AppStoreValidationService {
         app.appStoreValidationService
     }
+
+    var playStoreValidation: PlayStoreValidationService {
+        app.playStoreValidationService
+    }
 }

--- a/Sources/App/Entities/Receipts/Receipts.swift
+++ b/Sources/App/Entities/Receipts/Receipts.swift
@@ -2,3 +2,45 @@ import Foundation
 import Vapor
 
 public enum Receipts {}
+
+public extension Receipts {
+    enum Validate {
+        public struct Request: Codable, Equatable, Sendable {
+            public let platform: String
+            public let receiptData: String?
+            public let purchaseToken: String?
+            public let productId: String
+
+            public init(
+                platform: String,
+                receiptData: String? = nil,
+                purchaseToken: String? = nil,
+                productId: String
+            ) {
+                self.platform = platform
+                self.receiptData = receiptData
+                self.purchaseToken = purchaseToken
+                self.productId = productId
+            }
+        }
+
+        public struct Response: Codable, Equatable, Sendable {
+            public let success: Bool
+            public let status: String
+            public let transactionId: String?
+            public let error: String?
+
+            public init(
+                success: Bool,
+                status: String,
+                transactionId: String? = nil,
+                error: String? = nil
+            ) {
+                self.success = success
+                self.status = status
+                self.transactionId = transactionId
+                self.error = error
+            }
+        }
+    }
+}

--- a/Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift
+++ b/Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift
@@ -1,4 +1,86 @@
 import Fluent
 import Vapor
 
-struct ReceiptsController {}
+struct ReceiptsController {
+
+    func validate(_ req: Request) async throws -> Response {
+        let validateRequest = try req.content.decode(Receipts.Validate.Request.self)
+
+        // Validate product ID maps to a known credit amount
+        guard let creditAmount = Receipts.creditAmount(for: validateRequest.productId) else {
+            throw Abort(.badRequest, reason: "Unknown product ID '\(validateRequest.productId)'")
+        }
+
+        // Determine platform and validate
+        let transactionId: String
+        let platform: TransactionPlatform
+
+        switch validateRequest.platform.lowercased() {
+        case "ios":
+            guard let receiptData = validateRequest.receiptData, !receiptData.isEmpty else {
+                throw Abort(.badRequest, reason: "receiptData is required for iOS platform")
+            }
+            platform = .ios
+            do {
+                let result = try await req.services.appStoreValidation.verify(signedTransaction: receiptData)
+                transactionId = result.transactionId
+            } catch let validationError as AppStoreValidationError {
+                let body = Receipts.Validate.Response(
+                    success: false,
+                    status: "invalid",
+                    error: "\(validationError)"
+                )
+                return try await body.encodeResponse(status: .forbidden, for: req)
+            }
+
+        case "android":
+            guard let purchaseToken = validateRequest.purchaseToken, !purchaseToken.isEmpty else {
+                throw Abort(.badRequest, reason: "purchaseToken is required for Android platform")
+            }
+            platform = .android
+            do {
+                let result = try await req.services.playStoreValidation.verify(
+                    productId: validateRequest.productId,
+                    purchaseToken: purchaseToken
+                )
+                transactionId = result.transactionId
+            } catch let validationError as PlayStoreValidationError {
+                let body = Receipts.Validate.Response(
+                    success: false,
+                    status: "invalid",
+                    error: "\(validationError)"
+                )
+                return try await body.encodeResponse(status: .forbidden, for: req)
+            }
+
+        default:
+            throw Abort(.badRequest, reason: "Unsupported platform '\(validateRequest.platform)'")
+        }
+
+        // Check for duplicate transaction
+        if let existing = try await req.repositories.receipts.find(transactionId: transactionId) {
+            let body = Receipts.Validate.Response(
+                success: true,
+                status: "already_processed",
+                transactionId: existing.transactionId
+            )
+            return try await body.encodeResponse(status: .ok, for: req)
+        }
+
+        // Store new transaction
+        let transaction = TransactionModel(
+            transactionId: transactionId,
+            platform: platform,
+            productId: validateRequest.productId,
+            creditAmount: creditAmount
+        )
+        try await req.repositories.receipts.create(transaction)
+
+        let body = Receipts.Validate.Response(
+            success: true,
+            status: "valid",
+            transactionId: transactionId
+        )
+        return try await body.encodeResponse(status: .ok, for: req)
+    }
+}

--- a/Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift
+++ b/Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift
@@ -27,7 +27,7 @@ struct ReceiptsController {
                     let body = Receipts.Validate.Response(
                         success: false,
                         status: "invalid",
-                        error: "Product ID mismatch: receipt is for '\(result.productId)'"
+                        error: "Product ID does not match the validated receipt"
                     )
                     return try await body.encodeResponse(status: .forbidden, for: req)
                 }
@@ -55,7 +55,7 @@ struct ReceiptsController {
                     let body = Receipts.Validate.Response(
                         success: false,
                         status: "invalid",
-                        error: "Product ID mismatch: receipt is for '\(result.productId)'"
+                        error: "Product ID does not match the validated receipt"
                     )
                     return try await body.encodeResponse(status: .forbidden, for: req)
                 }

--- a/Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift
+++ b/Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift
@@ -23,6 +23,14 @@ struct ReceiptsController {
             platform = .ios
             do {
                 let result = try await req.services.appStoreValidation.verify(signedTransaction: receiptData)
+                guard result.productId == validateRequest.productId else {
+                    let body = Receipts.Validate.Response(
+                        success: false,
+                        status: "invalid",
+                        error: "Product ID mismatch: receipt is for '\(result.productId)'"
+                    )
+                    return try await body.encodeResponse(status: .forbidden, for: req)
+                }
                 transactionId = result.transactionId
             } catch let validationError as AppStoreValidationError {
                 let body = Receipts.Validate.Response(
@@ -43,6 +51,14 @@ struct ReceiptsController {
                     productId: validateRequest.productId,
                     purchaseToken: purchaseToken
                 )
+                guard result.productId == validateRequest.productId else {
+                    let body = Receipts.Validate.Response(
+                        success: false,
+                        status: "invalid",
+                        error: "Product ID mismatch: receipt is for '\(result.productId)'"
+                    )
+                    return try await body.encodeResponse(status: .forbidden, for: req)
+                }
                 transactionId = result.transactionId
             } catch let validationError as PlayStoreValidationError {
                 let body = Receipts.Validate.Response(

--- a/Sources/App/Modules/Receipts/Models/Receipts+Model.swift
+++ b/Sources/App/Modules/Receipts/Models/Receipts+Model.swift
@@ -4,3 +4,17 @@ import Vapor
 
 extension Receipts.Validate.Request: Content {}
 extension Receipts.Validate.Response: Content {}
+
+// MARK: - Product-to-Credits Mapping
+
+extension Receipts {
+    static let productCreditAmounts: [String: Int] = [
+        "credits_1": 1,
+        "credits_3": 3,
+        "credits_10": 10,
+    ]
+
+    static func creditAmount(for productId: String) -> Int? {
+        productCreditAmounts[productId]
+    }
+}

--- a/Sources/App/Modules/Receipts/Models/Receipts+Model.swift
+++ b/Sources/App/Modules/Receipts/Models/Receipts+Model.swift
@@ -1,1 +1,6 @@
-import Foundation
+import Vapor
+
+// MARK: - Content Conformance
+
+extension Receipts.Validate.Request: Content {}
+extension Receipts.Validate.Response: Content {}

--- a/Sources/App/Modules/Receipts/ReceiptsRouter.swift
+++ b/Sources/App/Modules/Receipts/ReceiptsRouter.swift
@@ -5,5 +5,19 @@ struct ReceiptsRouter: RouteCollection {
 
     let controller = ReceiptsController()
 
-    func boot(routes: RoutesBuilder) throws {}
+    func boot(routes: RoutesBuilder) throws {
+        let api = routes
+            .grouped("api")
+            .grouped("v1")
+            .grouped("receipts")
+            .groupedOpenAPI(tags: .init(name: "Receipts", description: "In-app purchase receipt validation"))
+
+        api
+            .post("validate", use: controller.validate)
+            .openAPI(
+                description: "Validate an in-app purchase receipt for iOS or Android. Returns validation status and transaction ID.",
+                body: .type(Receipts.Validate.Request.self),
+                response: .type(Receipts.Validate.Response.self)
+            )
+    }
 }

--- a/Tests/AppTests/Tests/ControllerTests/ReceiptsTests/ReceiptsControllerTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/ReceiptsTests/ReceiptsControllerTests.swift
@@ -263,7 +263,7 @@ struct ReceiptsControllerTests {
             expectContent(Receipts.Validate.Response.self, response) { body in
                 #expect(body.success == false)
                 #expect(body.status == "invalid")
-                #expect(body.error?.contains("mismatch") == true)
+                #expect(body.error?.contains("does not match") == true)
             }
         }
     }
@@ -289,7 +289,7 @@ struct ReceiptsControllerTests {
             expectContent(Receipts.Validate.Response.self, response) { body in
                 #expect(body.success == false)
                 #expect(body.status == "invalid")
-                #expect(body.error?.contains("mismatch") == true)
+                #expect(body.error?.contains("does not match") == true)
             }
         }
     }

--- a/Tests/AppTests/Tests/ControllerTests/ReceiptsTests/ReceiptsControllerTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/ReceiptsTests/ReceiptsControllerTests.swift
@@ -1,0 +1,285 @@
+@testable import App
+import Fluent
+import Testing
+import VaporTesting
+
+@Suite(.serialized)
+struct ReceiptsControllerTests {
+    let app: Application
+    let testWorld: IsolatedTestWorld
+    let validatePath = "api/v1/receipts/validate"
+
+    let mockAppStore: MockAppStoreValidationService
+    let mockPlayStore: MockPlayStoreValidationService
+
+    init() async throws {
+        testWorld = try await IsolatedTestWorld()
+        app = testWorld.app
+
+        // Configure mock validation services
+        let appStore = MockAppStoreValidationService()
+        let playStore = MockPlayStoreValidationService()
+        self.mockAppStore = appStore
+        self.mockPlayStore = playStore
+        app.appStoreValidationService = appStore
+        app.playStoreValidationService = playStore
+
+        // Configure receipts repository (uses database via migrations)
+        app.receiptsRepository = DatabaseReceiptsRepository(database: app.db)
+    }
+
+    // MARK: - iOS Validation Tests
+
+    @Test("Successful iOS validation returns valid status", .tags(.p0Critical, .integration))
+    func iosValidationSuccess() async throws {
+        mockAppStore.resultToReturn = AppStoreValidationResult(
+            transactionId: "ios_txn_123",
+            productId: "credits_1",
+            bundleId: "com.test.app",
+            purchaseDate: Date(),
+            environment: "Sandbox"
+        )
+
+        let requestBody = Receipts.Validate.Request(
+            platform: "ios",
+            receiptData: "valid-signed-transaction",
+            productId: "credits_1"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .ok)
+            expectContent(Receipts.Validate.Response.self, response) { body in
+                #expect(body.success == true)
+                #expect(body.status == "valid")
+                #expect(body.transactionId == "ios_txn_123")
+                #expect(body.error == nil)
+            }
+        }
+
+        #expect(mockAppStore.verifyCallCount == 1)
+        #expect(mockAppStore.lastSignedTransaction == "valid-signed-transaction")
+    }
+
+    // MARK: - Android Validation Tests
+
+    @Test("Successful Android validation returns valid status", .tags(.p0Critical, .integration))
+    func androidValidationSuccess() async throws {
+        mockPlayStore.resultToReturn = PlayStoreValidationResult(
+            transactionId: "GPA.1234-5678",
+            productId: "credits_3",
+            purchaseDate: Date()
+        )
+
+        let requestBody = Receipts.Validate.Request(
+            platform: "android",
+            purchaseToken: "valid-purchase-token",
+            productId: "credits_3"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .ok)
+            expectContent(Receipts.Validate.Response.self, response) { body in
+                #expect(body.success == true)
+                #expect(body.status == "valid")
+                #expect(body.transactionId == "GPA.1234-5678")
+                #expect(body.error == nil)
+            }
+        }
+
+        #expect(mockPlayStore.verifyCallCount == 1)
+        #expect(mockPlayStore.lastPurchaseToken == "valid-purchase-token")
+    }
+
+    // MARK: - Duplicate Transaction Tests
+
+    @Test("Duplicate transaction returns already_processed", .tags(.p0Critical, .integration))
+    func duplicateTransactionReturnsAlreadyProcessed() async throws {
+        // Pre-populate a transaction in the database
+        let existing = TransactionModel(
+            transactionId: "dup_txn_001",
+            platform: .ios,
+            productId: "credits_1",
+            creditAmount: 1
+        )
+        try await existing.create(on: app.db)
+
+        mockAppStore.resultToReturn = AppStoreValidationResult(
+            transactionId: "dup_txn_001",
+            productId: "credits_1",
+            bundleId: "com.test.app",
+            purchaseDate: Date(),
+            environment: "Sandbox"
+        )
+
+        let requestBody = Receipts.Validate.Request(
+            platform: "ios",
+            receiptData: "signed-data",
+            productId: "credits_1"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .ok)
+            expectContent(Receipts.Validate.Response.self, response) { body in
+                #expect(body.success == true)
+                #expect(body.status == "already_processed")
+                #expect(body.transactionId == "dup_txn_001")
+            }
+        }
+    }
+
+    // MARK: - Invalid Receipt Tests
+
+    @Test("Invalid iOS receipt returns 403 with invalid status", .tags(.p0Critical, .integration))
+    func invalidIosReceiptReturns403() async throws {
+        mockAppStore.errorToThrow = .invalidSignature
+
+        let requestBody = Receipts.Validate.Request(
+            platform: "ios",
+            receiptData: "bad-receipt",
+            productId: "credits_1"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .forbidden)
+            expectContent(Receipts.Validate.Response.self, response) { body in
+                #expect(body.success == false)
+                #expect(body.status == "invalid")
+                #expect(body.error != nil)
+            }
+        }
+    }
+
+    @Test("Invalid Android token returns 403 with invalid status", .tags(.p0Critical, .integration))
+    func invalidAndroidTokenReturns403() async throws {
+        mockPlayStore.errorToThrow = .invalidToken
+
+        let requestBody = Receipts.Validate.Request(
+            platform: "android",
+            purchaseToken: "bad-token",
+            productId: "credits_1"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .forbidden)
+            expectContent(Receipts.Validate.Response.self, response) { body in
+                #expect(body.success == false)
+                #expect(body.status == "invalid")
+                #expect(body.error != nil)
+            }
+        }
+    }
+
+    // MARK: - Malformed Request Tests
+
+    @Test("Unknown platform returns 400", .tags(.p1Core, .integration))
+    func unknownPlatformReturns400() async throws {
+        let requestBody = Receipts.Validate.Request(
+            platform: "windows",
+            productId: "credits_1"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("Unknown product ID returns 400", .tags(.p1Core, .integration))
+    func unknownProductIdReturns400() async throws {
+        let requestBody = Receipts.Validate.Request(
+            platform: "ios",
+            receiptData: "some-data",
+            productId: "unknown_product"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("iOS without receiptData returns 400", .tags(.p1Core, .integration))
+    func iosMissingReceiptDataReturns400() async throws {
+        let requestBody = Receipts.Validate.Request(
+            platform: "ios",
+            productId: "credits_1"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("Android without purchaseToken returns 400", .tags(.p1Core, .integration))
+    func androidMissingPurchaseTokenReturns400() async throws {
+        let requestBody = Receipts.Validate.Request(
+            platform: "android",
+            productId: "credits_1"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    // MARK: - Transaction Storage Tests
+
+    @Test("Successful validation stores transaction in database", .tags(.p1Core, .integration))
+    func successfulValidationStoresTransaction() async throws {
+        mockAppStore.resultToReturn = AppStoreValidationResult(
+            transactionId: "store_txn_789",
+            productId: "credits_10",
+            bundleId: "com.test.app",
+            purchaseDate: Date(),
+            environment: "Sandbox"
+        )
+
+        let requestBody = Receipts.Validate.Request(
+            platform: "ios",
+            receiptData: "valid-signed-data",
+            productId: "credits_10"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .ok)
+        }
+
+        // Verify transaction was stored
+        let stored = try await TransactionModel.query(on: app.db)
+            .filter(\.$transactionId == "store_txn_789")
+            .first()
+
+        #expect(stored != nil)
+        #expect(stored?.platform == .ios)
+        #expect(stored?.productId == "credits_10")
+        #expect(stored?.creditAmount == 10)
+    }
+
+    // MARK: - Product-to-Credits Mapping Tests
+
+    @Test("Product credit mapping is correct", .tags(.unit))
+    func productCreditMapping() {
+        #expect(Receipts.creditAmount(for: "credits_1") == 1)
+        #expect(Receipts.creditAmount(for: "credits_3") == 3)
+        #expect(Receipts.creditAmount(for: "credits_10") == 10)
+        #expect(Receipts.creditAmount(for: "unknown") == nil)
+    }
+}

--- a/Tests/AppTests/Tests/ControllerTests/ReceiptsTests/ReceiptsControllerTests.swift
+++ b/Tests/AppTests/Tests/ControllerTests/ReceiptsTests/ReceiptsControllerTests.swift
@@ -238,6 +238,62 @@ struct ReceiptsControllerTests {
         }
     }
 
+    // MARK: - Product ID Mismatch Tests
+
+    @Test("iOS product ID mismatch returns 403", .tags(.p0Critical, .integration))
+    func iosProductIdMismatchReturns403() async throws {
+        mockAppStore.resultToReturn = AppStoreValidationResult(
+            transactionId: "ios_txn_mismatch",
+            productId: "credits_1",
+            bundleId: "com.test.app",
+            purchaseDate: Date(),
+            environment: "Sandbox"
+        )
+
+        let requestBody = Receipts.Validate.Request(
+            platform: "ios",
+            receiptData: "valid-signed-transaction",
+            productId: "credits_10"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .forbidden)
+            expectContent(Receipts.Validate.Response.self, response) { body in
+                #expect(body.success == false)
+                #expect(body.status == "invalid")
+                #expect(body.error?.contains("mismatch") == true)
+            }
+        }
+    }
+
+    @Test("Android product ID mismatch returns 403", .tags(.p0Critical, .integration))
+    func androidProductIdMismatchReturns403() async throws {
+        mockPlayStore.resultToReturn = PlayStoreValidationResult(
+            transactionId: "GPA.mismatch",
+            productId: "credits_1",
+            purchaseDate: Date()
+        )
+
+        let requestBody = Receipts.Validate.Request(
+            platform: "android",
+            purchaseToken: "valid-token",
+            productId: "credits_10"
+        )
+
+        try await app.test(.POST, validatePath, beforeRequest: { req in
+            try req.content.encode(requestBody)
+        }) { response in
+            #expect(response.status == .forbidden)
+            expectContent(Receipts.Validate.Response.self, response) { body in
+                #expect(body.success == false)
+                #expect(body.status == "invalid")
+                #expect(body.error?.contains("mismatch") == true)
+            }
+        }
+    }
+
     // MARK: - Transaction Storage Tests
 
     @Test("Successful validation stores transaction in database", .tags(.p1Core, .integration))

--- a/docs/CONDITIONAL_DOCS.md
+++ b/docs/CONDITIONAL_DOCS.md
@@ -178,3 +178,11 @@ This guide helps you find relevant documentation based on what you're working on
     - When adding new platform-specific purchase verification services for Android
     - When troubleshooting Google OAuth2 service account authentication issues
     - When working with Google Play Developer API token exchange flow
+
+- docs/features/receipt-validation-endpoint.md
+  - Conditions:
+    - When implementing or modifying the receipt validation endpoint in the Receipts module
+    - When adding new in-app purchase product IDs or credit tiers
+    - When modifying platform-specific validation branching logic (iOS/Android)
+    - When working with custom HTTP status codes in Vapor controller responses
+    - When troubleshooting receipt validation error responses (400/403)

--- a/docs/features/receipt-validation-endpoint.md
+++ b/docs/features/receipt-validation-endpoint.md
@@ -1,0 +1,102 @@
+# Receipt Validation Endpoint
+
+**Date:** 2026-03-15
+**Related Files:** `Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift`, `Sources/App/Modules/Receipts/ReceiptsRouter.swift`, `Sources/App/Entities/Receipts/Receipts.swift`, `Sources/App/Modules/Receipts/Models/Receipts+Model.swift`
+
+## Overview
+
+A unified `POST /api/v1/receipts/validate` endpoint that validates in-app purchase receipts for both iOS (App Store) and Android (Play Store) platforms. The controller delegates to platform-specific validation services, enforces idempotency via duplicate transaction detection, maps products to credit amounts, and returns a consistent response shape across all outcomes.
+
+## What Was Built
+
+- `Receipts.Validate.Request` and `Receipts.Validate.Response` DTOs with `Content` conformance
+- `ReceiptsController.validate` action with platform branching, error handling, and transaction storage
+- `POST /api/v1/receipts/validate` route with OpenAPI documentation
+- Static product-to-credits mapping (`credits_1` → 1, `credits_3` → 3, `credits_10` → 10)
+- Product ID cross-validation against store receipt responses
+- 11 integration/unit tests covering all acceptance criteria
+
+## Technical Implementation
+
+### Key Files
+
+- `Sources/App/Entities/Receipts/Receipts.swift`: Defines `Receipts.Validate.Request` and `Receipts.Validate.Response` using the project's enum-based DTO pattern
+- `Sources/App/Modules/Receipts/Models/Receipts+Model.swift`: `Content` conformance for DTOs and `creditAmount(for:)` static helper
+- `Sources/App/Modules/Receipts/Controllers/ReceiptsController.swift`: Main validation logic with platform branching and error mapping
+- `Sources/App/Modules/Receipts/ReceiptsRouter.swift`: Route registration under `/api/v1/receipts` with OpenAPI metadata
+
+### Key Patterns
+
+- **Platform-Switching Controller**: The `validate` action branches on `platform.lowercased()` to dispatch to the correct validation service (`appStoreValidation` or `playStoreValidation`). Each branch validates platform-specific required fields (`receiptData` for iOS, `purchaseToken` for Android) before calling the service.
+
+- **Custom HTTP Status with Response Body**: Since Vapor's `Content` protocol returns HTTP 200 by default, the controller returns `Response` (not `Content`) and uses `body.encodeResponse(status:for:)` to set custom status codes (403 for invalid receipts, 200 for success/duplicate). This pattern is necessary when the same response DTO must be returned with different HTTP statuses.
+
+- **Error-Type-Specific Catch Blocks**: Platform validation errors are caught by their concrete types (`AppStoreValidationError`, `PlayStoreValidationError`) and mapped to a `{ success: false, status: "invalid", error: "..." }` response with HTTP 403. Unexpected errors propagate as standard Abort errors.
+
+- **Product ID Cross-Validation**: After store validation succeeds, the controller verifies that the `productId` returned by the store matches the `productId` in the request. A mismatch returns 403 with a generic error to prevent product spoofing.
+
+### Code Examples
+
+**Calling the validation endpoint:**
+```json
+// iOS request
+POST /api/v1/receipts/validate
+{
+  "platform": "ios",
+  "receiptData": "<signed-transaction-JWS>",
+  "productId": "credits_10"
+}
+
+// Android request
+POST /api/v1/receipts/validate
+{
+  "platform": "android",
+  "purchaseToken": "<purchase-token>",
+  "productId": "credits_3"
+}
+```
+
+**Response shapes:**
+```json
+// Success (200)
+{ "success": true, "status": "valid", "transactionId": "1000000123456789" }
+
+// Duplicate (200)
+{ "success": true, "status": "already_processed", "transactionId": "1000000123456789" }
+
+// Invalid receipt (403)
+{ "success": false, "status": "invalid", "error": "invalidSignature" }
+```
+
+**Adding a new product tier:**
+```swift
+// In Receipts+Model.swift
+static let productCreditAmounts: [String: Int] = [
+    "credits_1": 1,
+    "credits_3": 3,
+    "credits_10": 10,
+    "credits_25": 25,  // Add new tier here
+]
+```
+
+## How to Use
+
+1. Send a `POST` request to `/api/v1/receipts/validate` with platform, receipt data, and product ID
+2. The endpoint validates the receipt with the platform-specific service
+3. On success, the transaction is stored in the database with mapped credit amount
+4. Duplicate submissions return `already_processed` (idempotent, HTTP 200)
+5. Invalid receipts return HTTP 403 with error details
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `productCreditAmounts` | `[String: Int]` | 3 tiers | Maps product IDs to credit amounts; add new entries for new tiers |
+| Platform services | Service | Required | `appStoreValidation` and `playStoreValidation` must be registered on `Application` |
+
+## Notes
+
+- The response shape `{ success, status, transactionId?, error? }` is designed to support future `"status": "pending"` for async validation (Story 2.9)
+- Platform comparison is case-insensitive via `.lowercased()`
+- The `encodeResponse(status:for:)` pattern must be used (not returning `Content` directly) to support the 403 status for invalid receipts
+- Product-to-credits mapping is a static dictionary; for dynamic pricing, this would need to move to configuration or database

--- a/docs/features/receipts-module.md
+++ b/docs/features/receipts-module.md
@@ -73,7 +73,7 @@ if let existing = try await req.repositories.receipts.find(transactionId: storeT
 1. The module is registered in `Application-Setup.swift` and boots automatically
 2. The repository is available via `req.repositories.receipts` in any controller
 3. Use `find(transactionId:)` before creating records to enforce idempotency
-4. Controller endpoints will be added in Story 2.4 (Receipt Verification Endpoint)
+4. The validation endpoint is available at `POST /api/v1/receipts/validate` (see `docs/features/receipt-validation-endpoint.md`)
 
 ## Configuration
 
@@ -86,7 +86,7 @@ These values are enforced at the application level (future Story 2.4), not in th
 
 ## Notes
 
-- The controller, router, and model extension files are intentional stubs — endpoint logic will be implemented in Story 2.4
-- The `Receipts` entity namespace at `Entities/Receipts/Receipts.swift` is a placeholder for future DTOs
+- The validation endpoint is implemented in Story 2.4 — see `docs/features/receipt-validation-endpoint.md`
+- The `Receipts` entity namespace at `Entities/Receipts/Receipts.swift` contains `Validate.Request` and `Validate.Response` DTOs
 - Migration supports both SQLite (tests) and PostgreSQL (production)
 - The unique constraint on `transactionId` provides database-level protection against duplicate processing


### PR DESCRIPTION
## Summary

Implements a unified receipt validation endpoint (`POST /api/v1/receipts/validate`) that validates in-app purchase receipts for both iOS and Android platforms, enforces idempotency, maps products to credit amounts, and stores validated transactions.

## Changes

- Defined `Receipts.Validate.Request` and `Receipts.Validate.Response` DTOs with `Content` conformance
- Added static product-to-credits mapping (`credits_1` → 1, `credits_3` → 3, `credits_10` → 10) with `creditAmount(for:)` helper
- Added `playStoreValidation` accessor to `Request+Services`
- Implemented `ReceiptsController.validate` with platform branching (iOS/Android), duplicate detection, transaction storage, and error-type-specific catch blocks
- Registered `POST /api/v1/receipts/validate` route with OpenAPI documentation in `ReceiptsRouter`
- Added product ID cross-validation against store receipt responses (returns 403 on mismatch)
- Created 11 integration/unit tests covering all acceptance criteria
- Added feature documentation: `docs/features/receipt-validation-endpoint.md`
- Updated conditional docs guide with discoverability conditions

## Testing

All 11 tests pass covering:
- Successful iOS validation flow (mock AppStoreValidationService)
- Successful Android validation flow (mock PlayStoreValidationService)
- Duplicate transaction returns `already_processed` (idempotent)
- Invalid iOS receipt returns 403 with `invalid` status
- Invalid Android token returns 403 with `invalid` status
- Unknown platform returns 400
- Unknown product ID returns 400
- iOS missing `receiptData` returns 400
- Android missing `purchaseToken` returns 400
- Successful validation stores transaction in database with correct credit amount
- Product-to-credits mapping unit test

## Evidence

Lint and build validation passed. All tests pass via `swift test` with serialized test suite execution.


---
Linear: https://linear.app/rule/issue/RULE-137